### PR TITLE
Refactor Graph Update Flags and Improve Dependency Handling for Graph Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmograph/cosmos",
-  "version": "2.0.0-beta.25",
+  "version": "2.0.0-beta.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmograph/cosmos",
-      "version": "2.0.0-beta.25",
+      "version": "2.0.0-beta.26",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmograph/cosmos",
-  "version": "2.0.0-beta.25",
+  "version": "2.0.0-beta.26",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -390,6 +390,7 @@ export interface GraphConfigInterface {
   scalePointsOnZoom?: boolean;
   /**
    * Initial zoom level. Can be set once during graph initialization.
+   * If set, `fitViewOnInit` value will be ignored.
    * Default value: `undefined`
    */
   initialZoomLevel?: number;
@@ -412,6 +413,7 @@ export interface GraphConfigInterface {
   enableDrag?: boolean;
   /**
    * Whether to center and zoom the view to fit all points in the scene on initialization or not.
+   * Ignored if `initialZoomLevel` is set.
    * Default: `true`
    */
   fitViewOnInit?: boolean;

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -106,10 +106,11 @@ export class Lines extends CoreModule {
   }
 
   public draw (): void {
-    if (!this.pointsBuffer || !this.curveLineBuffer) return
+    if (!this.pointsBuffer) return
     if (!this.colorBuffer) this.updateColor()
     if (!this.widthBuffer) this.updateWidth()
     if (!this.arrowBuffer) this.updateArrow()
+    if (!this.curveLineGeometry) this.updateCurveLineGeometry()
     this.drawCurveCommand?.()
   }
 


### PR DESCRIPTION
This PR refactors the update mechanism in the Graph class by replacing the previous `_has*Changed` boolean flags with more descriptive `_needs*Update` flags. Setter methods are updated to set all relevant flags, ensuring that dependent updates (such as links and forces when point positions change) are properly triggered.

Additional Change:
Clarified the documentation for the `initialZoomLevel` and `fitViewOnInit` config properties.