### PR TITLE
Add WebGL error handling and remove `setFocusedPointByIndex` method

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,6 @@ export interface GraphConfigInterface {
 
   /**
    * Set focus on a point by index.  A ring will be highlighted around the focused point.
-   * Has priority over the `setFocusedPointByIndex` method.
    * When set to `undefined`, no point is focused.
    * Default value: `undefined`
    */

--- a/src/graph/utils/error-message.ts
+++ b/src/graph/utils/error-message.ts
@@ -1,0 +1,23 @@
+/**
+ * Creates and appends an error message element to the container
+ * @param container The HTML element to append the error message to
+ * @returns The created error div element
+ */
+export function createWebGLErrorMessage (container: HTMLElement): HTMLDivElement {
+  const errorDiv = document.createElement('div')
+  errorDiv.style.cssText = `
+    color: var(--cosmosgl-error-message-color);
+    padding: 0em 2em;
+    position: absolute;
+    top: 50%; left: 0; right: 0;
+    transform: translateY(-50%);
+    z-index: 1000;
+    font-family: inherit;
+    font-size: 1rem;
+    text-align: center;
+    user-select: none;
+  `
+  errorDiv.textContent = 'Sorry, your device or browser does not support the required WebGL features for this visualization'
+  container.appendChild(errorDiv)
+  return errorDiv
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -742,23 +742,6 @@ export class Graph {
   }
 
   /**
-   * Set focus on a point by index. A ring will be highlighted around the focused point.
-   * If no index is specified, the focus will be reset.
-   * If `focusedPointIndex` is specified in the config, this method will have no effect.
-   * @param index The index of the point in the array of points.
-   */
-  public setFocusedPointByIndex (index?: number): void {
-    if (this._isDestroyed) return
-    // Config `focusedPointIndex` parameter has higher priority than this method.
-    if (this.config.focusedPointIndex !== undefined) return
-    if (index === undefined) {
-      this.store.setFocusedPoint()
-    } else {
-      this.store.setFocusedPoint(index)
-    }
-  }
-
-  /**
    * Converts the X and Y point coordinates from the space coordinate system to the screen coordinate system.
    * @param spacePosition Array of x and y coordinates in the space coordinate system.
    * @returns Array of x and y coordinates in the screen coordinate system.
@@ -974,7 +957,6 @@ export class Graph {
     this.store.linksTextureSize = Math.ceil(Math.sqrt((graph.linksNumber ?? 0) * 2))
     this.create()
     this.initPrograms()
-    this.store.setFocusedPoint(this.config.focusedPointIndex)
     this.store.hoveredPoint = undefined
     this.start(simulationAlpha)
   }

--- a/src/modules/Store/index.ts
+++ b/src/modules/Store/index.ts
@@ -45,7 +45,8 @@ export class Store {
   public set backgroundColor (color: [number, number, number, number]) {
     this._backgroundColor = color
     const brightness = rgbToBrightness(color[0], color[1], color[2])
-    document.documentElement.style.setProperty('--cosmos-attribution-color', brightness > 0.65 ? 'black' : 'white')
+    document.documentElement.style.setProperty('--cosmosgl-attribution-color', brightness > 0.65 ? 'black' : 'white')
+    document.documentElement.style.setProperty('--cosmosgl-error-message-color', brightness > 0.65 ? 'black' : 'white')
     if (this.div) this.div.style.backgroundColor = `rgba(${color[0] * 255}, ${color[1] * 255}, ${color[2] * 255}, ${color[3]})`
   }
 

--- a/src/stories/2. configuration.mdx
+++ b/src/stories/2. configuration.mdx
@@ -17,7 +17,7 @@ import { Meta } from "@storybook/blocks";
 | renderHoveredPointRing | Turns ring rendering around a point on hover on / off | `false` |
 | hoveredPointRingColor | Hovered point ring color hex value or an array of RGBA values | `white` |
 | focusedPointRingColor | Focused point ring color hex value or an array of RGBA values | `white` |
-| focusedPointIndex | Set focus on a point by index. A ring will be highlighted around the focused point. Has priority over the `setFocusedPointByIndex` method. When set to `undefined`, no point is focused. | `undefined` |
+| focusedPointIndex | Set focus on a point by index. A ring will be highlighted around the focused point. When set to `undefined`, no point is focused. | `undefined` |
 | renderLinks | Turns link rendering on / off | `true` |
 | linkColor | The default color to use for links when no link colors are provided, or if the color value in the array is `undefined` or `null`. This can be either a hex color string (e.g., '#666666') or an array of RGBA values in the format `[red, green, blue, alpha]` where each value is a number between 0 and 255 | `#666666` |
 | linkGreyoutOpacity | Greyed out link opacity value when the selection is active | `0.1` |

--- a/src/stories/2. configuration.mdx
+++ b/src/stories/2. configuration.mdx
@@ -49,7 +49,9 @@ import { Meta } from "@storybook/blocks";
 | attribution | Controls the text shown in the bottom right corner. Provide HTML content as a string for custom attribution. Empty string hides attribution | `''` |
 | rescalePositions | Control automatic point position adjustment. When undefined: auto-rescale if simulation disabled | `undefined` |
 
-**Note:** The attribution text color can be customized using CSS variable `--cosmos-attribution-color`.
+**Notes:**
+- The attribution text color can be customized using CSS variable `--cosmosgl-attribution-color`.
+- Error message text color can be customized using CSS variable `--cosmosgl-error-message-color`.
 
 ## Simulation configuration
 

--- a/src/stories/3. api-reference.mdx
+++ b/src/stories/3. api-reference.mdx
@@ -281,14 +281,6 @@ This method returns an array of indices that are adjacent to a specific point in
 
 * **`index`** (Number): The index of the point whose adjacent points are to be retrieved.
 
-
-### <a name="set_focused_point_by_index" href="#set_focused_point_by_index">#</a> graph.<b>setFocusedPointByIndex</b>(<i>index</i>)
-
-This method highlights a specific point in the graph by placing a visual indicator, such as a ring, around it. If `focusedPointIndex` is specified [in the config](../?path=/docs/configuration--docs), this method will have no effect.
-
-* **`index`** (Number, optional): The index of the point to be focused. If not provided, the focus will be reset, and any existing highlight will be removed.
-
-
 ### <a name="space_to_screen_position" href="#space_to_screen_position">#</a> graph.<b>spaceToScreenPosition</b>(<i>coordinates</i>)
 
 This method method is used to convert X and Y point coordinates from the space coordinate system (which is typically used for graph data) to the screen coordinate system (which is used for rendering the graph on the display).

--- a/src/stories/beginners/basic-set-up/index.ts
+++ b/src/stories/beginners/basic-set-up/index.ts
@@ -47,7 +47,7 @@ export const basicSetUp = (): { graph: Graph; div: HTMLDivElement} => {
       }
       console.log('Clicked point index: ', index)
     },
-    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmos-attribution-color);" target="_blank">Cosmograph</a>',
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
   })
 
   const { pointPositions, links } = generateData()

--- a/src/stories/beginners/point-labels/index.ts
+++ b/src/stories/beginners/point-labels/index.ts
@@ -41,7 +41,7 @@ export const pointLabels = (
     simulationRepulsion: 0.4,
     onSimulationTick: () => cosmosLabels.update(graph),
     onZoom: () => cosmosLabels.update(graph),
-    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmos-attribution-color);" target="_blank">Cosmograph</a>',
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
   })
 
   graph.setPointPositions(new Float32Array(pointPositions))

--- a/src/stories/beginners/quick-start.ts
+++ b/src/stories/beginners/quick-start.ts
@@ -18,7 +18,7 @@ export const quickStart = (): { graph: Graph; div: HTMLDivElement} => {
     rescalePositions: true, // rescale positions
     enableDrag: true, // enable dragging points
     onClick: pointIndex => { console.log('Clicked point index: ', pointIndex) },
-    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmos-attribution-color);" target="_blank">Cosmograph</a>',
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
   /* ... */
   }
 

--- a/src/stories/beginners/remove-points/config.ts
+++ b/src/stories/beginners/remove-points/config.ts
@@ -20,5 +20,5 @@ export const config: GraphConfigInterface = {
   simulationRepulsion: 0.2,
   simulationGravity: 0.1,
   simulationDecay: 100000,
-  attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmos-attribution-color);" target="_blank">Cosmograph</a>',
+  attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
 }

--- a/src/stories/create-cosmos.ts
+++ b/src/stories/create-cosmos.ts
@@ -41,7 +41,7 @@ export const createCosmos = (props: CosmosStoryProps): { div: HTMLDivElement; gr
     simulationGravity: 0.02,
     simulationFriction: 0.7,
     simulationDecay: 10000000,
-    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmos-attribution-color);" target="_blank">Cosmograph</a>',
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
     ...props,
   }
 

--- a/src/stories/geospatial/moscow-metro-stations/index.ts
+++ b/src/stories/geospatial/moscow-metro-stations/index.ts
@@ -35,7 +35,7 @@ export const moscowMetroStations = (): {graph: Graph; div: HTMLDivElement} => {
     enableSimulation: false,
     enableDrag: false,
     fitViewOnInit: true,
-    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmos-attribution-color);" target="_blank">Cosmograph</a>',
+    attribution: 'visualized with <a href="https://cosmograph.app/" style="color: var(--cosmosgl-attribution-color);" target="_blank">Cosmograph</a>',
   })
 
   const pointColors = getPointColors(moscowMetroCoords)


### PR DESCRIPTION
- Added error handling for WebGL initialization with user-friendly message:

![photo_2025-05-14 09 04 24](https://github.com/user-attachments/assets/95c19dbd-f6af-42dc-a89f-f3b9c4e77f30)

- Introduced new CSS variable `--cosmosgl-error-message-color` for error display

**Breaking Changes ⚠️**
- Removed `setFocusedPointByIndex` method from Graph class
- Updated CSS variable naming (`--cosmos-attribution-color` → `--cosmosgl-attribution-color`)