### PR TITLE
Add support for multiple point shapes with 8 shape types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,8 +353,8 @@ export class Graph {
    *
    * @param {Float32Array} pointShapes - A Float32Array representing the shapes of points in the format [shape1, shape2, ..., shapen],
    * where `n` is the index of the point and each shape value corresponds to a PointShape enum:
-   * 0 = Circle, 1 = Rectangle, 2 = Triangle, 3 = Diamond, 4 = Pentagon, 5 = Hexagon, 6 = Star, 7 = Cross.
-   * Example: `new Float32Array([0, 1, 2])` sets the first point to Circle, the second point to Rectangle, and the third point to Triangle.
+   * 0 = Circle, 1 = Square, 2 = Triangle, 3 = Diamond, 4 = Pentagon, 5 = Hexagon, 6 = Star, 7 = Cross.
+   * Example: `new Float32Array([0, 1, 2])` sets the first point to Circle, the second point to Square, and the third point to Triangle.
    */
   public setPointShapes (pointShapes: Float32Array): void {
     if (this._isDestroyed) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export class Graph {
   private _needsPointPositionsUpdate = false
   private _needsPointColorUpdate = false
   private _needsPointSizeUpdate = false
+  private _needsPointShapeUpdate = false
   private _needsLinksUpdate = false
   private _needsLinkColorUpdate = false
   private _needsLinkWidthUpdate = false
@@ -303,6 +304,7 @@ export class Graph {
     // Point related textures depend on point positions length, so we need to update them
     this._needsPointColorUpdate = true
     this._needsPointSizeUpdate = true
+    this._needsPointShapeUpdate = true
     this._needsPointClusterUpdate = true
     this._needsForceManyBodyUpdate = true
     this._needsForceLinkUpdate = true
@@ -344,6 +346,20 @@ export class Graph {
     if (this._isDestroyed) return
     this.graph.inputPointSizes = pointSizes
     this._needsPointSizeUpdate = true
+  }
+
+  /**
+   * Sets the shapes for the graph points.
+   *
+   * @param {Float32Array} pointShapes - A Float32Array representing the shapes of points in the format [shape1, shape2, ..., shapen],
+   * where `n` is the index of the point and each shape value corresponds to a PointShape enum:
+   * 0 = Circle, 1 = Rectangle, 2 = Triangle, 3 = Diamond, 4 = Pentagon, 5 = Hexagon, 6 = Star, 7 = Cross.
+   * Example: `new Float32Array([0, 1, 2])` sets the first point to Circle, the second point to Rectangle, and the third point to Triangle.
+   */
+  public setPointShapes (pointShapes: Float32Array): void {
+    if (this._isDestroyed) return
+    this.graph.inputPointShapes = pointShapes
+    this._needsPointShapeUpdate = true
   }
 
   /**
@@ -1100,6 +1116,7 @@ export class Graph {
     if (this._needsPointPositionsUpdate) this.points.updatePositions()
     if (this._needsPointColorUpdate) this.points.updateColor()
     if (this._needsPointSizeUpdate) this.points.updateSize()
+    if (this._needsPointShapeUpdate) this.points.updateShape()
 
     if (this._needsLinksUpdate) this.lines.updatePointsBuffer()
     if (this._needsLinkColorUpdate) this.lines.updateColor()
@@ -1117,6 +1134,7 @@ export class Graph {
     this._needsPointPositionsUpdate = false
     this._needsPointColorUpdate = false
     this._needsPointSizeUpdate = false
+    this._needsPointShapeUpdate = false
     this._needsLinksUpdate = false
     this._needsLinkColorUpdate = false
     this._needsLinkWidthUpdate = false
@@ -1412,5 +1430,6 @@ export class Graph {
 }
 
 export type { GraphConfigInterface } from './config'
+export { PointShape } from './modules/GraphData'
 
 export * from './helper'

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -1,9 +1,22 @@
 import { getRgbaColor, isNumber } from '@/graph/helper'
 import { GraphConfig } from '@/graph/config'
+
+export enum PointShape {
+  Circle = 0,
+  Rectangle = 1,
+  Triangle = 2,
+  Diamond = 3,
+  Pentagon = 4,
+  Hexagon = 5,
+  Star = 6,
+  Cross = 7
+}
+
 export class GraphData {
   public inputPointPositions: Float32Array | undefined
   public inputPointColors: Float32Array | undefined
   public inputPointSizes: Float32Array | undefined
+  public inputPointShapes: Float32Array | undefined
   public inputLinkColors: Float32Array | undefined
   public inputLinkWidths: Float32Array | undefined
   public inputLinkStrength: Float32Array | undefined
@@ -14,6 +27,7 @@ export class GraphData {
   public pointPositions: Float32Array | undefined
   public pointColors: Float32Array | undefined
   public pointSizes: Float32Array | undefined
+  public pointShapes: Float32Array | undefined
 
   public inputLinks: Float32Array | undefined
   public links: Float32Array | undefined
@@ -104,6 +118,30 @@ export class GraphData {
       for (let i = 0; i < this.pointSizes.length; i++) {
         if (!isNumber(this.pointSizes[i])) {
           this.pointSizes[i] = this._config.pointSize
+        }
+      }
+    }
+  }
+
+  /**
+   * Updates the point shapes based on the input data or default shape (Circle).
+   */
+  public updatePointShape (): void {
+    if (this.pointsNumber === undefined) {
+      this.pointShapes = undefined
+      return
+    }
+
+    // Sets point shapes to default values (Circle) if the input is missing or does not match input points number.
+    if (this.inputPointShapes === undefined || this.inputPointShapes.length !== this.pointsNumber) {
+      this.pointShapes = new Float32Array(this.pointsNumber).fill(PointShape.Circle)
+    } else {
+      this.pointShapes = new Float32Array(this.inputPointShapes)
+      const pointShapes = this.pointShapes
+      for (let i = 0; i < pointShapes.length; i++) {
+        const shape = pointShapes[i]
+        if (shape == null || !isNumber(shape) || shape < 0 || shape > 7) {
+          pointShapes[i] = PointShape.Circle
         }
       }
     }
@@ -222,6 +260,7 @@ export class GraphData {
     this.updatePoints()
     this.updatePointColor()
     this.updatePointSize()
+    this.updatePointShape()
 
     this.updateLinks()
     this.updateLinkColor()

--- a/src/modules/GraphData/index.ts
+++ b/src/modules/GraphData/index.ts
@@ -3,7 +3,7 @@ import { GraphConfig } from '@/graph/config'
 
 export enum PointShape {
   Circle = 0,
-  Rectangle = 1,
+  Square = 1,
   Triangle = 2,
   Diamond = 3,
   Pentagon = 4,

--- a/src/modules/Points/draw-points.frag
+++ b/src/modules/Points/draw-points.frag
@@ -14,7 +14,7 @@ const float smoothing = 0.9;
 
 // Shape constants
 const float CIRCLE = 0.0;
-const float RECTANGLE = 1.0;
+const float SQUARE = 1.0;
 const float TRIANGLE = 2.0;
 const float DIAMOND = 3.0;
 const float PENTAGON = 4.0;
@@ -27,7 +27,7 @@ float circleDistance(vec2 p) {
     return dot(p, p);
 }
 
-float rectangleDistance(vec2 p) {
+float squareDistance(vec2 p) {
     vec2 d = abs(p) - vec2(0.8);
     return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
 }
@@ -119,7 +119,7 @@ float crossDistance(vec2 p) {
 }
 
 float getShapeDistance(vec2 p, float shape) {
-    if (shape == RECTANGLE) return rectangleDistance(p);
+    if (shape == SQUARE) return squareDistance(p);
     else if (shape == TRIANGLE) return triangleDistance(p);
     else if (shape == DIAMOND) return diamondDistance(p);
     else if (shape == PENTAGON) return pentagonDistance(p);

--- a/src/modules/Points/draw-points.frag
+++ b/src/modules/Points/draw-points.frag
@@ -1,4 +1,4 @@
-// Fragment shader for rendering points with a smooth circular edge
+// Fragment shader for rendering points with various shapes and smooth edges
 
 #ifdef GL_ES
 precision highp float;
@@ -7,9 +7,127 @@ precision highp float;
 // The color and alpha values from the vertex shader
 varying vec3 rgbColor;
 varying float alpha;
+varying float pointShape;
 
-// Smoothing control the smoothness of the point’s edge
+// Smoothing controls the smoothness of the point's edge
 const float smoothing = 0.9;
+
+// Shape constants
+const float CIRCLE = 0.0;
+const float RECTANGLE = 1.0;
+const float TRIANGLE = 2.0;
+const float DIAMOND = 3.0;
+const float PENTAGON = 4.0;
+const float HEXAGON = 5.0;
+const float STAR = 6.0;
+const float CROSS = 7.0;
+
+// Distance functions for different shapes
+float circleDistance(vec2 p) {
+    return dot(p, p);
+}
+
+float rectangleDistance(vec2 p) {
+    vec2 d = abs(p) - vec2(0.8);
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+float triangleDistance(vec2 p) {
+    const float k = sqrt(3.0);   // ≈1.732; slope of 60° lines for an equilateral triangle
+    p.x = abs(p.x) - 0.9;        // fold the X axis and shift: brings left and right halves together
+    p.y = p.y + 0.55;             // move the whole shape up slightly so it is centred vertically
+
+    // reflect points that fall outside the main triangle back inside, to reuse the same maths
+    if (p.x + k * p.y > 0.0)
+        p = vec2(p.x - k * p.y,  -k * p.x - p.y) / 2.0;
+
+    p.x -= clamp(p.x, -1.0, 0.0); // clip any remainder on the left side
+
+    // Return signed distance: negative = inside; positive = outside
+    return -length(p) * sign(p.y);
+}
+
+float diamondDistance(vec2 p) {
+    // aspect > 1  →  taller diamond
+    const float aspect = 1.2;
+    return abs(p.x) + abs(p.y) / aspect - 0.8;
+}
+
+float pentagonDistance(vec2 p) {
+    // Regular pentagon signed-distance (Inigo Quilez)
+    const vec3 k = vec3(0.809016994, 0.587785252, 0.726542528);
+    p.x = abs(p.x);
+
+    // Reflect across the two tilted edges ─ only if point is outside
+    p -= 2.0 * min(dot(vec2(-k.x, k.y), p), 0.0) * vec2(-k.x, k.y);
+    p -= 2.0 * min(dot(vec2( k.x, k.y), p), 0.0) * vec2( k.x, k.y);
+
+    // Clip against the top horizontal edge (keeps top point sharp)
+    p -= vec2(clamp(p.x, -k.z * k.x, k.z * k.x), k.z);
+
+    // Return signed distance (negative → inside, positive → outside)
+    return length(p) * sign(p.y);
+}
+
+float hexagonDistance(vec2 p) {
+    const vec3 k = vec3(-0.866025404, 0.5, 0.577350269);
+    p = abs(p);
+    p -= 2.0 * min(dot(k.xy, p), 0.0) * k.xy;
+    p -= vec2(clamp(p.x, -k.z * 0.8, k.z * 0.8), 0.8);
+    return length(p) * sign(p.y);
+}
+
+float starDistance(vec2 p) {
+    // 5-point star signed-distance function (adapted from Inigo Quilez)
+    // r  – outer radius, rf – inner/outer radius ratio
+    const float r  = 0.9;
+    const float rf = 0.45;
+
+    // Pre-computed rotation vectors for the star arms (36° increments)
+    const vec2 k1 = vec2(0.809016994, -0.587785252);
+    const vec2 k2 = vec2(-k1.x, k1.y);
+
+    // Fold the plane into a single arm sector
+    p.x = abs(p.x);
+    p -= 2.0 * max(dot(k1, p), 0.0) * k1;
+    p -= 2.0 * max(dot(k2, p), 0.0) * k2;
+    p.x = abs(p.x);
+
+    // Translate so the top tip of the star lies on the X-axis
+    p.y -= r;
+
+    // Vector describing the edge between an outer tip and its adjacent inner point
+    vec2 ba = rf * vec2(-k1.y, k1.x) - vec2(0.0, 1.0);
+    // Project the point onto that edge and clamp the projection to the segment
+    float h = clamp(dot(p, ba) / dot(ba, ba), 0.0, r);
+
+    // Return signed distance (negative => inside, positive => outside)
+    return length(p - ba * h) * sign(p.y * ba.x - p.x * ba.y);
+}
+
+float crossDistance(vec2 p) {
+    // Signed distance function for a cross (union of two rectangles)
+    // Adapted from Inigo Quilez (https://iquilezles.org/)
+    // Each arm has half-sizes 0.3 (thickness) and 0.8 (length)
+    p = abs(p);
+    if (p.y > p.x) p = p.yx;       // exploit symmetry
+
+    vec2 q = p - vec2(0.8, 0.3);   // subtract half-sizes (length, thickness)
+
+    // Standard rectangle SDF, then take union of the two arms
+    return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0);
+}
+
+float getShapeDistance(vec2 p, float shape) {
+    if (shape == RECTANGLE) return rectangleDistance(p);
+    else if (shape == TRIANGLE) return triangleDistance(p);
+    else if (shape == DIAMOND) return diamondDistance(p);
+    else if (shape == PENTAGON) return pentagonDistance(p);
+    else if (shape == HEXAGON) return hexagonDistance(p);
+    else if (shape == STAR) return starDistance(p);
+    else if (shape == CROSS) return crossDistance(p);
+    else return circleDistance(p); // Default to circle
+}
 
 void main() {
     // Discard the fragment if the point is fully transparent
@@ -17,10 +135,17 @@ void main() {
 
     // Calculate coordinates within the point
     vec2 pointCoord = 2.0 * gl_PointCoord - 1.0;
-    // Calculate squared distance from the center
-    float pointCenterDistance = dot(pointCoord, pointCoord);
-    // Calculate opacity based on distance and smoothing
-    float opacity = alpha * (1.0 - smoothstep(smoothing, 1.0, pointCenterDistance));
+    
+    float opacity;
+    if (pointShape == CIRCLE) {
+        // For circles, use the original distance calculation
+        float pointCenterDistance = dot(pointCoord, pointCoord);
+        opacity = alpha * (1.0 - smoothstep(smoothing, 1.0, pointCenterDistance));
+    } else {
+        // For other shapes, use the shape distance function
+        float shapeDistance = getShapeDistance(pointCoord, pointShape);
+        opacity = alpha * (1.0 - smoothstep(-0.01, 0.01, shapeDistance));
+    }
 
     gl_FragColor = vec4(rgbColor, opacity);
 }

--- a/src/modules/Points/draw-points.vert
+++ b/src/modules/Points/draw-points.vert
@@ -5,6 +5,7 @@ precision highp float;
 attribute vec2 pointIndices;
 attribute float size;
 attribute vec4 color;
+attribute float shape;
 
 uniform sampler2D positionsTexture;
 uniform sampler2D pointGreyoutStatus;
@@ -27,6 +28,7 @@ uniform bool skipUnselected;
 varying vec2 textureCoords;
 varying vec3 rgbColor;
 varying float alpha;
+varying float pointShape;
 
 float calculatePointSize(float size) {
   float pSize;
@@ -72,6 +74,7 @@ void main() {
 
   rgbColor = color.rgb;
   alpha = color.a * pointOpacity;
+  pointShape = shape;
 
   // Adjust alpha of selected points
   if (greyoutStatus.r > 0.0) {

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -34,6 +34,7 @@ export class Points extends CoreModule {
   private colorBuffer: regl.Buffer | undefined
   private sizeFbo: regl.Framebuffer2D | undefined
   private sizeBuffer: regl.Buffer | undefined
+  private shapeBuffer: regl.Buffer | undefined
   private trackedIndicesFbo: regl.Framebuffer2D | undefined
   private trackedPositionsFbo: regl.Framebuffer2D | undefined
   private sampledPointsFbo: regl.Framebuffer2D | undefined
@@ -221,6 +222,10 @@ export class Points extends CoreModule {
           color: {
             buffer: () => this.colorBuffer,
             size: 4,
+          },
+          shape: {
+            buffer: () => this.shapeBuffer,
+            size: 1,
           },
         },
         uniforms: {
@@ -520,6 +525,13 @@ export class Points extends CoreModule {
     })
   }
 
+  public updateShape (): void {
+    const { reglInstance, data } = this
+    if (data.pointsNumber === undefined || data.pointShapes === undefined) return
+    if (!this.shapeBuffer) this.shapeBuffer = reglInstance.buffer(0)
+    this.shapeBuffer(data.pointShapes)
+  }
+
   public updateSampledPointsGrid (): void {
     const { store: { screenSize }, config: { pointSamplingDistance }, reglInstance } = this
     let dist = pointSamplingDistance ?? Math.min(...screenSize) / 2
@@ -544,6 +556,7 @@ export class Points extends CoreModule {
     const { config: { renderHoveredPointRing, pointSize }, store, data } = this
     if (!this.colorBuffer) this.updateColor()
     if (!this.sizeBuffer) this.updateSize()
+    if (!this.shapeBuffer) this.updateShape()
 
     // Render in layers: unselected points first (behind), then selected points (in front)
     if (store.selectedIndices && store.selectedIndices.length > 0) {

--- a/src/stories/3. api-reference.mdx
+++ b/src/stories/3. api-reference.mdx
@@ -75,6 +75,39 @@ This method retrieves the current sizes of the graph points that were previously
 
 The returned array contains the processed point sizes used for rendering, including any default values that were applied during processing.
 
+### <a name="set_point_shapes" href="#set_point_shapes">#</a> graph.<b>setPointShapes</b>(<i>pointShapes</i>)
+
+This method sets the shapes for the graph points.
+
+* **`pointShapes`** (Float32Array): A Float32Array representing the shapes of points in the format `[shape1, shape2, ..., shapeN]`, where each `shape` value corresponds to the shape of the point at the same index in the graph's data. Each shape value should be one of the available shape constants:
+
+| Shape Value | Shape Name |
+|-------------|------------|
+| 0 | Circle |
+| 1 | Rectangle |
+| 2 | Triangle |
+| 3 | Diamond |
+| 4 | Pentagon |
+| 5 | Hexagon |
+| 6 | Star |
+| 7 | Cross |
+
+Each shape value in the array specifies the shape of a point using the same order as the points in the graph data. Invalid shape values (outside the range 0-7) will default to Circle (0).
+
+**Example:**
+```javascript
+import { Graph, PointShape } from '@cosmos.gl/graph'
+
+// Create a mixed set of shapes using the PointShape enum
+graph.setPointShapes(new Float32Array([
+  PointShape.Circle,   // Circle for first point
+  PointShape.Star,     // Star for second point
+  PointShape.Triangle, // Triangle for third point
+  PointShape.Hexagon   // Hexagon for fourth point
+]));
+graph.render();
+```
+
 ### <a name="set_links" href="#set_links">#</a> graph.<b>setLinks</b>(<i>links</i>)
 
 This method sets the links (connections) between points in a cosmos.gl graph.

--- a/src/stories/3. api-reference.mdx
+++ b/src/stories/3. api-reference.mdx
@@ -84,7 +84,7 @@ This method sets the shapes for the graph points.
 | Shape Value | Shape Name |
 |-------------|------------|
 | 0 | Circle |
-| 1 | Rectangle |
+| 1 | Square |
 | 2 | Triangle |
 | 3 | Diamond |
 | 4 | Pentagon |

--- a/src/stories/shapes.stories.ts
+++ b/src/stories/shapes.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta } from '@storybook/html'
+
+import { createStory, Story } from '@/graph/stories/create-story'
+import { CosmosStoryProps } from './create-cosmos'
+import { allShapes } from './shapes/all-shapes'
+
+import allShapesStoryRaw from './shapes/all-shapes/index?raw'
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta: Meta<CosmosStoryProps> = {
+  title: 'Examples/Shapes',
+}
+
+export const AllShapes: Story = {
+  ...createStory(allShapes),
+  name: 'All Point Shapes',
+  parameters: {
+    sourceCode: [
+      { name: 'Story', code: allShapesStoryRaw },
+    ],
+  },
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta

--- a/src/stories/shapes/all-shapes/index.ts
+++ b/src/stories/shapes/all-shapes/index.ts
@@ -1,0 +1,69 @@
+import { Graph, PointShape } from '@cosmos.gl/graph'
+
+export const allShapes = (): {div: HTMLDivElement; graph: Graph } => {
+  // Create container div
+  const div = document.createElement('div')
+  div.style.height = '100vh'
+  div.style.width = '100%'
+
+  // Create 8 points, one for each shape
+  const spaceSize = 4096
+  const pointCount = 8
+  const spacing = spaceSize / pointCount
+
+  const pointPositions = new Float32Array(pointCount * 2)
+  const pointColors = new Float32Array(pointCount * 4)
+  const pointShapes = new Float32Array(pointCount)
+
+  // Define distinct colors for each shape
+  const shapeColors: [number, number, number][] = [
+    [1.0, 0.42, 0.38], // Coral for Circle
+    [0.13, 0.55, 0.45], // Forest Green for Rectangle
+    [0.25, 0.32, 0.71], // Royal Blue for Triangle
+    [0.96, 0.76, 0.19], // Amber Gold for Diamond
+    [0.74, 0.24, 0.45], // Deep Rose for Pentagon
+    [0.18, 0.55, 0.56], // Teal for Hexagon
+    [0.85, 0.45, 0.28], // Terracotta for Star
+    [0.58, 0.44, 0.86], // Periwinkle for Cross
+  ]
+
+  // Position points in a horizontal line
+  const startX = spacing / 2
+  const centerY = spaceSize / 2
+  for (let i = 0; i < pointCount; i++) {
+    // Position: horizontal line, centered
+    pointPositions[i * 2] = startX + i * spacing
+    pointPositions[i * 2 + 1] = centerY
+
+    // Color: distinct color for each shape
+    const color = shapeColors[i] || [1.0, 1.0, 1.0] // fallback to white if undefined
+    pointColors[i * 4] = color[0] // R
+    pointColors[i * 4 + 1] = color[1] // G
+    pointColors[i * 4 + 2] = color[2] // B
+    pointColors[i * 4 + 3] = 1.0 // A
+
+    // Shape: cycle through all available shapes
+    pointShapes[i] = i as PointShape
+  }
+
+  // Create graph with minimal configuration
+  const graph = new Graph(div, {
+    spaceSize,
+    pointSize: spacing / 2,
+    enableSimulation: false,
+    scalePointsOnZoom: true,
+    renderHoveredPointRing: true,
+    hoveredPointRingColor: '#ffffff',
+    rescalePositions: false,
+    enableDrag: true,
+  })
+
+  // Set data
+  graph.setPointPositions(pointPositions)
+  graph.setPointColors(pointColors)
+  graph.setPointShapes(pointShapes)
+
+  graph.render()
+
+  return { div, graph }
+}

--- a/src/stories/shapes/all-shapes/index.ts
+++ b/src/stories/shapes/all-shapes/index.ts
@@ -18,7 +18,7 @@ export const allShapes = (): {div: HTMLDivElement; graph: Graph } => {
   // Define distinct colors for each shape
   const shapeColors: [number, number, number][] = [
     [1.0, 0.42, 0.38], // Coral for Circle
-    [0.13, 0.55, 0.45], // Forest Green for Rectangle
+    [0.13, 0.55, 0.45], // Forest Green for Square
     [0.25, 0.32, 0.71], // Royal Blue for Triangle
     [0.96, 0.76, 0.19], // Amber Gold for Diamond
     [0.74, 0.24, 0.45], // Deep Rose for Pentagon


### PR DESCRIPTION
<img width="772" alt="Screenshot 2025-07-04 at 13 49 03" src="https://github.com/user-attachments/assets/a719e83d-d4d5-40bd-9445-697aba4ee069" />


- **PointShape enum** with 8 shape types:
  - Circle (default)
  - Square  
  - Triangle
  - Diamond
  - Pentagon
  - Hexagon
  - Star
  - Cross

- **New API method**: `setPointShapes(pointShapes: Float32Array)`

#### Usage Example
```javascript
import { Graph, PointShape } from '@cosmos.gl/graph'

graph.setPointShapes(new Float32Array([
  PointShape.Circle,   // Regular nodes
  PointShape.Star,     // Important nodes
  PointShape.Triangle, // Special categories
  PointShape.Diamond   // Key connectors
]));
```
