### PR TITLE
Add `fitViewByPointIndices` configuration property

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -493,6 +493,12 @@ export interface GraphConfigInterface {
    */
   fitViewByPointsInRect?: [[number, number], [number, number]] | [number, number][];
   /**
+   * When `fitViewOnInit` is set to `true`, fits the view to show only the specified points by their indices.
+   * Takes precedence over `fitViewByPointsInRect` when both are provided.
+   * Default: `undefined`
+   */
+  fitViewByPointIndices?: number[];
+  /**
    * Providing a `randomSeed` value allows you to control
    * the randomness of the layout across different simulation runs.
    * It is useful when you want the graph to always look the same on same datasets.
@@ -605,6 +611,7 @@ export class GraphConfig implements GraphConfigInterface {
   public fitViewPadding = defaultConfigValues.fitViewPadding
   public fitViewDuration = defaultConfigValues.fitViewDuration
   public fitViewByPointsInRect = undefined
+  public fitViewByPointIndices = undefined
 
   public randomSeed = undefined
   public pointSamplingDistance = defaultConfigValues.pointSamplingDistance

--- a/src/index.ts
+++ b/src/index.ts
@@ -525,7 +525,7 @@ export class Graph {
   public render (simulationAlpha?: number): void {
     if (this._isDestroyed || !this.reglInstance) return
     this.graph.update()
-    const { fitViewOnInit, fitViewDelay, fitViewPadding, fitViewDuration, fitViewByPointsInRect, initialZoomLevel } = this.config
+    const { fitViewOnInit, fitViewDelay, fitViewPadding, fitViewDuration, fitViewByPointsInRect, fitViewByPointIndices, initialZoomLevel } = this.config
     if (!this.graph.pointsNumber && !this.graph.linksNumber) {
       this.stopFrames()
       select(this.canvas).style('cursor', null)
@@ -540,7 +540,8 @@ export class Graph {
     // If `initialZoomLevel` is set, we don't need to fit the view
     if (this._isFirstRenderAfterInit && fitViewOnInit && initialZoomLevel === undefined) {
       this._fitViewOnInitTimeoutID = window.setTimeout(() => {
-        if (fitViewByPointsInRect) this.setZoomTransformByPointPositions(fitViewByPointsInRect, fitViewDuration, undefined, fitViewPadding)
+        if (fitViewByPointIndices) this.fitViewByPointIndices(fitViewByPointIndices, fitViewDuration, fitViewPadding)
+        else if (fitViewByPointsInRect) this.setZoomTransformByPointPositions(fitViewByPointsInRect, fitViewDuration, undefined, fitViewPadding)
         else this.fitView(fitViewDuration, fitViewPadding)
       }, fitViewDelay)
     }

--- a/src/stories/2. configuration.mdx
+++ b/src/stories/2. configuration.mdx
@@ -48,6 +48,7 @@ import { Meta } from "@storybook/blocks";
 | fitViewPadding | Extra space around points when fitting view | `0.1` |
 | fitViewDuration | Animation duration for fit view operation in milliseconds | `250` |
 | fitViewByPointsInRect | When `fitViewOnInit` is set to `true`, fits the view to show the points within a rectangle defined by its two corner coordinates `[[left, bottom], [right, top]]` in the scene space | `undefined` |
+| fitViewByPointIndices | When `fitViewOnInit` is set to `true`, fits the view to show only the specified points by their indices. Takes precedence over `fitViewByPointsInRect` when both are provided. | `undefined` |
 | randomSeed | Providing a value allows control over layout randomness for consistency across simulations. Applied only on initialization | `undefined` |
 | pointSamplingDistance | Sampling density for point position methods (used in `getSampledPointPositionsMap`) in pixels | `150` |
 | attribution | Controls the text shown in the bottom right corner. Provide HTML content as a string for custom attribution. Empty string hides attribution | `''` |


### PR DESCRIPTION
Adds a new configuration property `fitViewByPointIndices` that allows users to fit the view to specific points by their indices when `fitViewOnInit` is enabled.

## Usage
```typescript
const graph = new Graph(div, {
  fitViewOnInit: true,
  fitViewByPointIndices: [0, 5, 10, 15], // Focus on specific points
  fitViewDuration: 500,
  fitViewPadding: 0.2
})
```

## Behavior & Precedence
When `fitViewOnInit` is `true`, the priority order is:
1. `fitViewByPointIndices` (if provided) - **NEW**
2. `fitViewByPointsInRect` (if provided)
3. `fitView()` (default - all points)
