### PR TITLE
Patch release 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmos.gl/graph",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/core": "~9.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos.gl/graph",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "GPU-based force graph layout and rendering",
   "jsdelivr": "dist/index.min.js",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump `@cosmos.gl/graph` 3.4.0 → 3.4.1.

Patch release shipping the bug-fix collection from #250 — no breaking changes, no new API:

- Multiple Graph instances on one page no longer interfere with each other
- Runtime config changes (`pointSamplingDistance`, `linkSamplingDistance`, `pointDefaultSize`, `enableZoom`) now take effect immediately
- GPU data reads are exact on every graph size — clusters no longer drift onto neighbors
- Rect/polygon selection no longer returns points that don't exist
- Collision force covers its full range — large points no longer overlap
- `linkBlending: false`: clean opaque link edges, and greyed-out links are hidden instead of drawn at full strength
- Invalid input arrays (odd lengths, bad link endpoints, `NaN` strengths) are neutralized instead of corrupting the layout or crashing
- Tracked point positions survive point-count changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 3.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->