### PR TITLE
Import gl-bench's ES entry

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,12 @@
     "import/no-default-export": "error",
     "import/prefer-default-export": 0,
     "import/first": ["error", "absolute-first"],
+    "no-restricted-imports": ["error", {
+      "paths": [{
+        "name": "gl-bench",
+        "message": "Import 'gl-bench/dist/gl-bench.module.js'; the bare name resolves to gl-bench's export-less browser script."
+      }]
+    }],
     "import/order": ["error", 
       {
         "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object"],

--- a/src/modules/FPSMonitor/index.ts
+++ b/src/modules/FPSMonitor/index.ts
@@ -1,5 +1,9 @@
 
-import GLBench from 'gl-bench'
+// gl-bench's `browser` entry is an export-less script, so a bare `gl-bench`
+// specifier yields no default export in bundlers that honor that field. The
+// ES entry is imported by path: gl-bench stays external, the consumer's
+// bundler resolves this specifier, and no `browser` field redirects a path.
+import GLBench from 'gl-bench/dist/gl-bench.module.js'
 import { benchCSS } from './css'
 
 export class FPSMonitor {


### PR DESCRIPTION
Vite 8's bundler (rolldown) refuses gl-bench's `browser` entry, an IIFE with no exports. `npm create vite` scaffolds Vite 8 now, so every new app importing the package fails to build:

```
[MISSING_EXPORT] "default" is not exported by "node_modules/gl-bench/dist/gl-bench.min.js"
  12 │ import ct from "gl-bench";
```

Vite 7 accepted the same input. webpack and esbuild build it, then throw "not a constructor" in `Graph` when `showFPSMonitor` is on.

```ts
// before
import GLBench from 'gl-bench'

// after
import GLBench from 'gl-bench/dist/gl-bench.module.js'
```

A path bypasses the `browser` field in every bundler. gl-bench stays external; a lint rule rejects the bare name.

## Validation

Packed tarball, scratch consumer projects:

| | |
|---|---|
| Published 3.4.1, Vite 8 | fails as above |
| This branch, Vite 8 and Vite 7 | builds |
| Built app, headless Chromium | monitor renders, no errors |

## Next: our own frame monitor

gl-bench has been unmaintained since 2022, and its GPU tracking was never on in cosmos: the wrapper asks a WebGL 2 canvas for a `webgl` context and gets `null`. Even with a context, its GPU number is a `getError()` poll per draw, not a timer query. No WebGPU path.

GPU time is the number that matters here. FPS caps at the refresh rate and CPU time stays flat while the GPU does the work after `submit()`.

Proposal, not a gl-bench replica:

- **Readout:** `fps`, `cpu ms`, `gpu ms`, `gpu mb`. Text, small, scoped to the container.
- **GPU time:** one timestamp pair per frame, monitor-owned, public luma API only:

  ```ts
  const q = device.createQuerySet({ type: 'timestamp', count: 2 })
  q.writeTimestamp(0)               // frame start
  // ... simulation and draw passes ...
  device.submit()
  q.writeTimestamp(1)
  q.readTimestampDuration(0, 1).then(addGpuSample)
  ```

  One query per frame, per graph on a shared device. Not luma's per-pass debug profiler: that prototype leaked a poller per drag frame and needed four private members.
- **GPU memory:** `device.statsManager`.
- **WebGPU:** same `timestamp-query` feature; the timer sits behind a small interface so the WebGPU write path drops in.
- **No timer support:** `gpu —`. Everything else works everywhere, including headless CI.
- **Later, on demand:** per-stage breakdown, LoAF, a metrics callback.

No dependency beyond luma. `showFPSMonitor` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the FPS monitor’s gl-bench import so it loads the correct module and remains compatible with browser builds.
* **Chores**
  * Added linting guidance to prevent use of the incompatible bare gl-bench import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
