### PR TITLE
Disable multisampling on the default framebuffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1969,6 +1969,11 @@ export class Graph {
     return await luma.createDevice({
       type: 'webgl',
       adapters: [webgl2Adapter],
+      webgl: {
+        // Point and link edges are anti-aliased analytically in the shaders;
+        // multisampling the default framebuffer would only add fill cost.
+        antialias: false,
+      },
       createCanvasContext: {
         canvas, // Provide existing canvas
         useDevicePixels: this.config.pixelRatio, // Use config pixelRatio value


### PR DESCRIPTION
Creates the WebGL device with `antialias: false`.

```ts
webgl: { antialias: false },
```

The point and link shaders compute their own edge coverage — `smoothstep` on the shape SDF for points, on the stroke edge for links — so MSAA on the default framebuffer redoes that work at four samples per pixel and multiplies the fill cost of every link fragment. Link-heavy scenes are fill-bound, so it is the dominant cost in them. The regl-era context was created this way from the first commit; the luma.gl port dropped the attribute.

## Numbers

M3, Chrome on Metal, 200k points and 1M links, 1200×800 CSS px at pixel ratio 2, simulation off, every frame readback-serialized:

| links | before | after |
|---|---|---|
| blended (default) | 472 ms | 100 ms |
| `linkBlending: false` | 163 ms | 104 ms |

## Output

Points and blended links are unchanged: mean difference 0.03/255 on a dense scene with mixed shapes, curved links and arrows. MSAA never reached an alpha ramp inside a primitive.

Unblended links keep their hard edge and lose the partial silhouette smoothing MSAA gave them — that mode is the deliberately opaque fast path for big graphs, so its contract holds.

Devices passed in via `devicePromise` keep whatever `antialias` they request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Graphics rendering now uses a framebuffer without default antialiasing.
  * This provides more consistent rendering behavior across supported devices and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->