### PR TITLE
One-device-pixel edge anti-aliasing, centred on the edge

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -42,6 +42,7 @@ const preview: Preview = {
             'Camera',
             'Updating Data',
             'Showcase',
+            'Rendering',
             'Performance',
           ],
         ],

--- a/history/2026/2026-09-10-edge-ramps.md
+++ b/history/2026/2026-09-10-edge-ramps.md
@@ -1,0 +1,209 @@
+<!-- suggested path: history/2026/2026-09-10-edge-ramps.md -->
+# Edge ramps: one device pixel, centred on the edge
+
+**Date:** 2026-09-10
+**Commits:** `fix(points): close the triangle field's segment at the apex — the ramp holds on every edge` (`48f887f`), `fix(points): clamp the pentagon field to the true half side` (`16a66da`), `fix(points): composite the outline ring over a transparent body` (`7a6d9c7`), `perf(points, links): centre a one-device-pixel edge ramp on every edge` (`ad201be`), `refactor(points): one size rule for draw, ring, picking and selection` (`d855646`), `fix(points): pad the selection rectangle in CSS px — the footprint is the drawn point` (`1df6d42`), `feat(stories): edge anti-aliasing check at 0.5×, 1×, 2×, in a Rendering section` (`94a8e2b`)
+**PR:** <!-- TODO -->
+
+## Why
+
+Every edge ramp in the point, link and ring shaders was a fraction of its shape: the last 5% of
+a circle's radius, half a CSS pixel for a link, 2.5% and 5% of a ring's radius. Tuned when the
+canvas was always 2× and the browser's downsample supplied the anti-aliasing. `pixelRatio`
+follows the display since v3, so a 1× monitor gets the shader's ramps alone.
+
+```text
+  Big point (~20 px)                 Small point (~4 px)
+  ████████░░░░                       ██░
+  ██████████░░  ramp ~1 px           ███  ramp ~0.1 px → hard edge
+  ████████░░░░                       ██░
+```
+
+A 4 px point has no ramp at all. A 1 px link's is half a pixel, and a shallow link shows a
+ladder that crawls as it moves.
+
+The obvious fix, one device pixel of ramp placed inside the edge, was measured and set aside.
+It removes the ladder, but a fade inside the edge is a hard edge moved inward by half a ramp.
+A 1 px link keeps 38% of its ink and peaks at alpha 0.49, a 4 px point keeps 62%, and the
+hover and outline rings, which multiply one ramp per edge, vanish on any point under about
+30 px.
+
+## What changed
+
+One constant, `EDGE_RAMP_PX = 1.0` in `variables.ts`, reaches the point, link and highlight
+programs as a `#define`, the way the exit defaults do. Every edge gets a ramp that wide,
+centred on the edge.
+
+```text
+  coverage
+  1 |███████░░
+    |         ●        0.5 exactly on the geometric edge
+  0 |__________░░___   half the ramp inside, half outside
+```
+
+A centred fade integrates to the same area as a hard edge, so a shape keeps its ink at every
+size and pixel ratio, and its rendered size matches what a legend draws with SVG or CSS. Half
+the fade is outside the shape, so the primitive either grows by one ramp or clips the outer
+half. Links and rings grow; a point's sprite does not (see the frame times below).
+
+```text
+  link quad                              point sprite
+  |← — — — — — — — — — — — →|           ┌──────────┐
+  | ½ ramp | true shape | ½ ramp |       │ ·´    `· │  the disc touches the sides:
+                                         │:        :│  the outer half of the fade is
+                                         │ `·    ·´ │  clipped there, whole on the diagonals
+                                         └──────────┘
+```
+
+- **Links.** The quad is `max(width, ramp) + ramp` wide and the fragment fades over the outer
+  ramp width, so the ramp straddles the stroke's edge. An arrowed link's body and head edges
+  are fractions of the arrow width, so they are rescaled to the padded quad before their
+  ramps are centred on them. Dash caps and dot edges fade over the same ramp; dots are sized
+  to the stroke, not the padded quad. A new `pixelRatio` uniform converts the ramp to space
+  units.
+- **Points.** The sprite is the shape's own size, so the fade's outer half is clipped where
+  the shape meets the sprite's sides — a circle at its four axis points, whole on the
+  diagonals. A padded sprite was built and measured (below): it keeps every pixel of ink but
+  costs 12–45% of the frame on million-point scenes, against 0–14% without the padding, for
+  92% of a 4 px circle's ink and 78% of a 2 px one's. The shape's cap is the hardware limit
+  itself: a capped point clips the fade's outer half like any other, so the ramp of room the
+  padded design reserved under the limit is gone with it. An outlined sprite still pads for
+  its ring. The circle's ramp runs along
+  the radius rather than in r², which skews coverage outward on a small disc: a length and a
+  smoothstep. The other shapes size their ramp from their distance field's gradient per pixel,
+  so a diamond gets the same fade as a square; the field and its derivatives are evaluated in
+  the polygon branch only. Every fragment of a sprite shares `pointShape`, so the branch is
+  coherent and the derivatives are defined; evaluating them for every shape, on the theory
+  that derivatives want uniform control flow, cost the circle a field, two derivatives and a
+  square root per fragment it never read — a tenth of the points pass (below).
+- **One size rule.** The size in device pixels — pixel ratio, zoom, the hardware cap — is
+  one GLSL function (`point-size.glsl`, a luma shader module) shared by
+  the draw, ring, picking and rectangle-selection programs, and `spaceToScreenRadius` mirrors
+  it on the CPU with the same cap and the 1 px floor. What is drawn, hovered, selected and
+  measured is one size; the copies that used to be kept in step by comment are gone. Making
+  the unit explicit showed rectangle selection padding its CSS-px rectangle by a device-px
+  size, a footprint twice the drawn point on a 2× display since before this work; it now
+  converts, and the footprint is the drawn point at every pixel ratio (its own commit: a
+  behaviour change, not part of the refactor).
+- **Shape fields.** Two fields were not the distances they claimed, found while checking the
+  ramp on every shape. The triangle clamped its edge segment to −1.0 where the construction
+  needs −2r = −1.8 (Quilez's `sdEquilateralTriangle`), so the field jumped ±0.35–0.8 across
+  the apex-side 44% of each slanted edge and those edges got no ramp at all, on `main` too.
+  The pentagon clamped to `k.z·k.x` = 0.588 where its corners fold to ±r·tan 36° = 0.528:
+  wrong outside the corners only, contour unchanged. Both now match the exact Euclidean
+  distance to their polygon to four decimals, |∇d| = 1 off the folds, so the ramp holds on
+  every edge of every shape.
+- **Rings.** Both rings become a band on the ring's centre line with the ramp on each edge.
+  The outline sprite and the focus quad pad a full ramp per side, not the link quad's half:
+  a ring thinner than the ramp is widened to a one-ramp core centred on its band, whose outer
+  fade reaches up to a full ramp past the geometric edge (exactly `1 − band/2`); the focus
+  ring gains a `pixelRatio` uniform. When the hardware cap clamps an outlined sprite, the ring
+  tightens onto the body instead of leaving the sprite, pulled in by half a ramp: a ring that
+  large is never widened, so its fade ends half a ramp past its edge, on the sprite's. Both
+  rings are sized from the drawn core, so a point under a pixel carries the 1 px point's ring
+  rather than one shrinking into its own body; at that size a ring is a dot in its colour
+  either way, since its band is never thinner than the ramp.
+
+Unblended links (`linkBlending: false`) cannot carry a fade in alpha, so the fragment keeps
+the pixels whose centre is inside the stroke, coverage 0.5 being the geometric edge, and the
+vertex stage floors them at one device pixel instead of the ramp. Hard edges at the true
+width; a link under a pixel is a one-pixel line.
+
+Thinner than the ramp, each element keeps the property that matters for it:
+
+| element | rule |
+|---|---|
+| link | drawn at ramp width, `alpha = width / ramp` (ink preserved; a 1 px link on 1× is exactly one ramp wide and untouched, a 0.5 px link peaks at 0.5) |
+| arrowed link | the rule is applied to the head width, which is what the quad holds; a body under the ramp inside a head that is not keeps its own geometry, brighter and thinner than a plain link of the same width (a 0.5 px body on 1× peaks at 0.84 over ~1.5 px; ink 0.53, not lost) while the head draws as is. Accepted: flooring the body would widen or dim the head, the part of an arrowed link one looks at |
+| ring | drawn at ramp width, alpha stays 1 (visibility preserved) |
+| point under 1 px | 1 px core, `alpha = shape² / core²` (ink preserved; the GPU rasterises no smaller sprite, and a full-alpha pixel deposited up to five times the point's area) |
+| unblended dot | diameter at least √2 device px, so a dot always holds a pixel centre and the hard cut cannot erase it |
+| size 0, width 0 | nothing: the sprite, the focus ring's quad and the link quad are culled in the vertex stage, before the floor or the ramp can widen an absent element; `spaceToScreenRadius` returns 0 and picking and rectangle selection skip the point, so the CPU, hover and selection agree with the draw |
+
+1.0 is the box filter: a straight edge deposits in each pixel exactly the area it covers.
+A wider ramp reads softer on a 1× display and costs sprite area; 1.3 was tried and measured,
+about a tenth more frame time on small points for the softer edge, and 1.0 stayed.
+
+The second commit fixes the outline ring's compositing. `mix(body, ring, alpha)` with alpha
+`max(body, ring)` tinted a partially covered ring pixel with the point's colour outside the
+body and, after the blend, applied the ring's alpha twice; a 20 px point's ring put 9 px² of
+ink on screen where its coverage said 25. The composite is now source-over with the body's
+alpha as its weight.
+
+## Measured
+
+Ink is coverage summed over pixels against the nominal area or width, at pixel ratio 1 on an
+M3, Chrome on Metal:
+
+| element | before | now | padded sprite |
+|---|---|---|---|
+| 1 px link, ink / peak alpha | 0.74–1.00 / 1.00, by sub-pixel position | 0.96–1.00 / 1.00 | — |
+| 0.5 px link, ink | 0.24–1.00 | 0.96–1.00 | — |
+| 2 px point, ink | 0.95 | 0.78 | 1.00 |
+| 4 px point, ink | 0.95 | 0.92 | 1.00 |
+| 8 px point, ink | 0.95 | 0.97 | 1.00 |
+| 20 px point, ink | 0.95 | 0.99 | 1.00 |
+| outline ring on a 4 px point | 0.18 px wide | 1.0 px wide, full alpha | same |
+
+Frame time, milliseconds per frame: the same frame drawn ten times back to back with a GPU
+drain (`renderFrame` ×10, `finish` + `readPixels`), median of seven, best of two interleaved
+rounds; M3 via ANGLE Metal, 800×600 CSS px canvas at the scene's pixel ratio, simulation off,
+everything fitted on screen, the four states interleaved in one run. `main` → padded sprite →
+the shape's own sprite with the field and its gradient evaluated for every shape → this
+branch:
+
+| scene | main | padded sprite | field on every shape | now |
+|---|---|---|---|---|
+| 1M points, 4 css @2× = 8 device px | 28.7 | 32.2 (1.12×) | 29.5 (1.03×) | 29.0 (1.01×) |
+| 1M points, 4 css @1× = 4 device px | 14.7 | 21.2 (1.45×) | 18.4 (1.26×) | 16.7 (1.14×) |
+| 1M points, 2 css @2× = 4 device px | 23.4 | 34.0 (1.45×) | 26.6 (1.14×) | 25.0 (1.07×) |
+| 1M points, 0.8 css @2× = 1.6 device px | 21.0 | 28.4 (1.35×) | 22.0 (1.05×) | 21.4 (1.02×) |
+| 1M points, 0.4 css @2× = 0.8 device px | 20.3 | 24.2 (1.19×) | 20.8 (1.02×) | 20.4 (1.00×) |
+| 100k points, 32 css @2× = 64 device px | 11.9 | 13.1 (1.10×) | 12.8 (1.08×) | 12.1 (1.01×) |
+| 1M points, square, 8 device px | 28.8 | 33.0 (1.15×) | 30.2 (1.05×) | 30.3 (1.05×) |
+| 1M points, 8 device px, occlusion culling off | 39.4 | 51.1 (1.30×) | 44.3 (1.13×) | 39.4 (1.00×) |
+| 50k points / 500k links, 1 css @2× | 19.1 | 19.4 (1.01×) | 19.3 (1.01×) | 19.3 (1.01×) |
+| 50k / 500k links, 1 css @1× | 10.1 | 11.3 (1.13×) | 11.1 (1.11×) | 10.8 (1.08×) |
+| 50k / 500k links, 0.25 css @2× | 16.2 | 17.9 (1.10×) | 17.9 (1.11×) | 17.6 (1.09×) |
+| 50k / 500k links, 1 css @2×, unblended | 11.6 | 11.7 (1.01×) | 11.5 (0.99×) | 11.5 (1.00×) |
+| 50k / 500k links, 3 css @2× | 25.9 | 26.2 (1.01×) | 25.9 (1.00×) | 25.9 (1.00×) |
+
+Two costs, one per column. The padding is rasterization: a sprite of s device px rasterises
+≈ s² fragments per pass and both occlusion passes shade it; padding it by one ramp is
+(s+1)²/s², which is what the second column pays on small points, and on a small point the
+opaque core is a fraction of a pixel, so the core pass shades the sprite and discards it. The
+field on every shape is the shader: the single-pass row has no core to hide behind and shows
+it whole, 13% of the points pass, gone once the circle stops evaluating a field it never
+reads; the 64 px row says the same. What remains at 4 device px is the ramp itself. The
+opaque core, the fragments the depth-writing pass keeps, is `r < R − ½`: 56% of a 4 px disc
+against 90% for `main`'s 5%-of-radius ramp, and the rest goes through the blended pass under
+thirty-fold overdraw. Narrower is no anti-aliasing. Links keep their padded quad
+(`max(width, ramp) + ramp`): their cost is dominated by the vertex work and shows as 0–9%,
+the 1× and sub-pixel rows, where the quad widens, being the two that move.
+
+Set aside: skipping the core pass for points under ~10 device px, which halves the padded
+sprite's cost with identical output, is unneeded once the sprite is the shape; an inside ramp
+with no padding costs the same as this and keeps only 62% of a 4 px point's ink and 50% of a
+2 px point's; a hard-edge opt-in mode stays the honest escape hatch for million-point clouds
+if these numbers are still too high.
+
+## Example
+
+`src/stories/rendering/anti-aliasing/` — Storybook *Examples → Rendering → "Edge Anti-aliasing
+at 0.5×, 1×, 2×"*. One scene in three panes at pixel ratio 0.5, 1 and 2 with a shared camera:
+every shape plain and outlined at 0.5–16 px, and a ring of links 0.25–8 px wide at every
+angle; scrolling sweeps every size through the ramp on all three. SVG reference rings mark
+each circle's exact nominal diameter, so the rendered size can be read against what a legend
+would draw. Toggles for `linkBlending`, arrows, curved links, scale on zoom and the link
+style. The same story run against `main` shows the stair-steps and dropouts this entry
+describes.
+
+## Notes
+
+- Sprites under one pixel are rasterised at one pixel with `gl_PointCoord` spanning it, so
+  the old shaders drew a sub-pixel point at a full pixel; the one-pixel core with area alpha
+  is the same footprint at the right ink. A zero `gl_PointSize` is not culled either: the
+  spec leaves it undefined and this platform draws a full pixel, hence the explicit cull.
+- Each treatment was checked against a per-pixel model of it on plain WebGL 2; the GPU
+  stays within 0.03 of the model except for the old rings, whose ramps are thinner than the
+  GPU's sub-pixel precision.

--- a/history/2026/2026-09-10-edge-ramps.md
+++ b/history/2026/2026-09-10-edge-ramps.md
@@ -3,7 +3,7 @@
 
 **Date:** 2026-09-10
 **Commits:** `fix(points): close the triangle field's segment at the apex — the ramp holds on every edge` (`48f887f`), `fix(points): clamp the pentagon field to the true half side` (`16a66da`), `fix(points): composite the outline ring over a transparent body` (`7a6d9c7`), `perf(points, links): centre a one-device-pixel edge ramp on every edge` (`ad201be`), `refactor(points): one size rule for draw, ring, picking and selection` (`d855646`), `fix(points): pad the selection rectangle in CSS px — the footprint is the drawn point` (`1df6d42`), `feat(stories): edge anti-aliasing check at 0.5×, 1×, 2×, in a Rendering section` (`94a8e2b`)
-**PR:** <!-- TODO -->
+**PR:** [#262](https://github.com/cosmosgl/graph/pull/262)
 
 ## Why
 

--- a/src/modules/Lines/draw-curve-line.frag
+++ b/src/modules/Lines/draw-curve-line.frag
@@ -81,12 +81,18 @@ void main() {
   }
 
   if (useArrow > 0.5) {
-    float arrowWidthDelta = arrowWidthFactor / 2.0;
-    float linkCoverage = smoothstep(0.5 - arrowWidthDelta, 0.5 - arrowWidthDelta - smoothing / 2.0, abs(pos.y));
+    // pos.y spans the quad, which is the arrow width plus a ramp. arrowWidthFactor is a fraction
+    // of the arrow width alone, so edges derived from it scale by (1 - smoothing) = arrow / quad.
+    float preRamp = 1.0 - smoothing;
+    float bodyEdge = (0.5 - arrowWidthFactor / 2.0) * preRamp;
+    float headBase = 0.5 * preRamp;
+    // Body edge, ramp centred on it as for the plain stroke.
+    float linkCoverage = smoothstep(bodyEdge + smoothing / 2.0, bodyEdge - smoothing / 2.0, abs(pos.y));
     float arrowCoverage = 1.0;
     if (pos.x > start_arrow && pos.x < start_arrow + arrowLength) {
-      float xmapped = map(pos.x, start_arrow, end_arrow, 0.0, 1.0);
-      arrowCoverage = smoothstep(xmapped - smoothing, xmapped, map(abs(pos.y), 0.5, 0.0, 0.0, 1.0));
+      // Arrowhead taper, from headBase at its base to the centreline at its tip; ramp centred on it.
+      float taper = headBase * (1.0 - map(pos.x, start_arrow, end_arrow, 0.0, 1.0));
+      arrowCoverage = 1.0 - smoothstep(taper - smoothing / 2.0, taper + smoothing / 2.0, abs(pos.y));
       if (linkCoverage != arrowCoverage) {
         linkCoverage = max(linkCoverage, arrowCoverage);
       }
@@ -100,20 +106,29 @@ void main() {
     bool inArrowHead = (useArrow > 0.5) && (pos.x > start_arrow) && (pos.x < end_arrow);
     if (!inArrowHead) {
       // Distance along the link in the dash pattern's space (screen px or world units; see the vertex shader).
-      // fwidth() gives the screen-space rate of change, so anti-aliasing stays ~1px wide in either space.
+      // fwidth() gives the screen-space rate of change, so the ramp is EDGE_RAMP_PX device pixels in either space.
       float phase = clamp(pos.x, 0.0, 1.0) * vLinkDashSpan;
       if (vLinkStyle == LINK_STYLE_DASHED) {
         float period = max(linkDashLength + linkDashGap, 0.001);
-        float aa = max(fwidth(phase), 1e-4);
+        // Half a ramp in the pattern's units: fwidth(phase) is the change in phase per device pixel.
+        float aa = max(fwidth(phase), 1e-4) * (EDGE_RAMP_PX * 0.5);
         coverage *= strokeMask(phase, linkDashLength, period, aa);
       } else {
-        // Dotted: round dots sized to the stroke width, spaced by diameter + gap.
-        float diameter = vLinkDashWidth;
+        // Dotted: round dots sized to the stroke, the quad less its ramp; spaced by diameter + gap.
+        float diameter = vLinkDashWidth * (1.0 - smoothing);
+        if (linkBlending < 0.5) {
+          // Unblended keeps only pixels whose centre is inside the dot. A dot under √2 device
+          // px can miss every pixel centre and vanish; at √2 it always holds one. Pattern units
+          // per device pixel from the phase's gradient (the pattern space is isotropic).
+          float pxInPattern = max(length(vec2(dFdx(phase), dFdy(phase))), 1e-4);
+          diameter = max(diameter, 1.4142136 * pxInPattern);
+        }
         float period = max(diameter + linkDashGap, 0.001);
         float localX = mod(phase, period) - period * 0.5;
         float localY = pos.y * vLinkDashWidth;
         float r = length(vec2(localX, localY));
-        float aa = max(fwidth(r), 1e-4);
+        // Half a ramp in the pattern's units: fwidth(r) is the change in r per device pixel.
+        float aa = max(fwidth(r), 1e-4) * (EDGE_RAMP_PX * 0.5);
         coverage *= 1.0 - smoothstep(diameter * 0.5 - aa, diameter * 0.5 + aa, r);
       }
     }
@@ -134,12 +149,12 @@ void main() {
     if (opacity <= 0.0) discard;
     fragColor = vec4(linkIndex, 0.0, 0.0, 1.0);
   } else if (linkBlending < 0.5) {
-    // Unblended: any covered fragment is fully opaque. Soft AA fringes would
-    // otherwise write full RGB with partial alpha; canvas compositing treats that
-    // as premultiplied and the edge reads brighter than the solid core.
-    // Discard only zero coverage / fully transparent — do not hard-cut at
-    // coverage < 0.5, which erases thin strokes whose smoothstep peaks ~0.5.
-    if (coverage <= 0.0 || opacity <= 0.0) discard;
+    // Unblended: opaque, hard edges. Soft fringes would write full RGB with partial
+    // alpha; canvas compositing treats that as premultiplied and the edge reads
+    // brighter than the solid core. Every fade is centred on its geometric edge, so
+    // coverage 0.5 is that edge: keep the pixels whose centre is inside the stroke.
+    // The vertex stage keeps unblended strokes at least a device pixel wide.
+    if (coverage < 0.5 || opacity <= 0.0) discard;
     fragColor = vec4(color, 1.0);
   } else {
     fragColor = vec4(color, opacity);

--- a/src/modules/Lines/draw-curve-line.vert
+++ b/src/modules/Lines/draw-curve-line.vert
@@ -47,6 +47,7 @@ layout(std140) uniform drawLineUniforms {
   vec4 pointDefaultColor;
   float linkColorInterpolateFromEndpoints;
   float linkBlending;
+  float pixelRatio;
 } drawLine;
 
 #define transformationMatrix drawLine.transformationMatrix
@@ -77,6 +78,7 @@ layout(std140) uniform drawLineUniforms {
 #define pointDefaultColor drawLine.pointDefaultColor
 #define linkColorInterpolateFromEndpoints drawLine.linkColorInterpolateFromEndpoints
 #define linkBlending drawLine.linkBlending
+#define pixelRatio drawLine.pixelRatio
 #else
 uniform mat3 transformationMatrix;
 uniform float widthScale;
@@ -107,6 +109,7 @@ uniform float animatePositions;
 uniform vec4 pointDefaultColor;
 uniform float linkColorInterpolateFromEndpoints;
 uniform float linkBlending;
+uniform float pixelRatio;
 #endif
 
 out vec4 rgbaColor;
@@ -249,6 +252,12 @@ void main() {
   
   // Calculate line width using the width scale
   float linkWidth = lineWidthBase * widthScale;
+  // A width of 0 draws nothing, as a point of size 0 does: culled here, before the hover and
+  // focus increases and the one-pixel floor could widen an absent link. Not pickable either.
+  if (linkWidth <= 0.0) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
   float k = 2.0;
   // Arrow width is proportionally larger than the line width
   float arrowWidth = linkWidth * k;
@@ -295,13 +304,26 @@ void main() {
       linkWidthPx += focusedLinkWidthIncrease / transformationMatrix[0][0];
     }
   }
-  float smoothingPx = 0.5 / transformationMatrix[0][0];
+  // Center a one-ramp-wide fade on each stroke edge.
+  // Strokes thinner than the ramp use the ramp width with reduced alpha.
+  // Units: EDGE_RAMP_PX is device px; / pixelRatio → CSS px; / k → world, k = transformationMatrix[0][0]
+  // (the matrix carries no DPR). Widths are extruded in world space, so unlike gl_PointSize they
+  // never multiply by pixelRatio. The *Px values below are world units.
+  float smoothingPx = (EDGE_RAMP_PX / pixelRatio) / transformationMatrix[0][0];
+  float thinAlpha = min(linkWidthPx / smoothingPx, 1.0);
+  float minWidthPx = smoothingPx;
+  if (linkBlending < 0.5) {
+    // Unblended strokes cannot be dimmed: the fragment cuts them at the edge instead, and a
+    // stroke under a device pixel is drawn one pixel wide (its body, when it has an arrowhead).
+    thinAlpha = 1.0;
+    float bodyShare = useArrow > 0.5 ? 1.0 - arrowWidthFactor : 1.0;
+    // One device px → world, the same chain as the ramp.
+    minWidthPx = (1.0 / pixelRatio) / transformationMatrix[0][0] / bodyShare;
+  }
+  linkWidthPx = max(linkWidthPx, minWidthPx) + smoothingPx;
   smoothing = smoothingPx / linkWidthPx;
-  linkWidthPx += smoothingPx;
 
-  // Link thickness expressed in the dash pattern's space, so dotted-link dots match the stroke width.
-  // linkWidthPx is in world units; `dashUnitScale` converts it to screen px (scaleLinksOnZoom = false)
-  // or keeps it in world units (scaleLinksOnZoom = true), matching vLinkDashSpan.
+  // Quad width (stroke + ramp) in vLinkDashSpan's pattern-space units; the fragment takes the ramp back off.
   vLinkDashWidth = linkWidthPx * dashUnitScale;
 
 
@@ -312,6 +334,8 @@ void main() {
   float opacity = lineColor.a * linkOpacity * max(linkVisibilityMinTransparency, map(linkDistPx, linkVisibilityDistanceRange.g, linkVisibilityDistanceRange.r, 0.0, 1.0));
   // Fade with the exit ramp of the endpoints (1 = both fully present).
   opacity *= exitPresence;
+  // A stroke drawn at ramp width: alpha scales it back to its true width.
+  opacity *= thinAlpha;
 
   // Apply greyed-out status from the link status texture. Blended rendering dims
   // greyed links by greyoutOpacity. Unblended rendering hides them instead: alpha is

--- a/src/modules/Lines/index.ts
+++ b/src/modules/Lines/index.ts
@@ -9,7 +9,7 @@ import fillGridWithSampledLinksFrag from '@/graph/modules/Lines/fill-sampled-lin
 import fillGridWithSampledLinksVert from '@/graph/modules/Lines/fill-sampled-links.vert?raw'
 import { PickingReadback } from '@/graph/modules/Points/picking-readback'
 import { resolvePickedLinkIndex } from '@/graph/modules/Points/picking-utils'
-import { defaultConfigValues, EXIT_DEFAULT_COLOR_CHANNEL } from '@/graph/variables'
+import { defaultConfigValues, EXIT_DEFAULT_COLOR_CHANNEL, EDGE_RAMP_PX } from '@/graph/variables'
 import { getCurveLineGeometry } from '@/graph/modules/Lines/geometry'
 import { updateAttributeBuffer, updateAttributeBuffers } from '@/graph/modules/Shared/buffer'
 import { getBytesPerRow } from '@/graph/modules/Shared/texture-utils'
@@ -113,6 +113,7 @@ export class Lines extends CoreModule {
       pointDefaultColor: [number, number, number, number];
       linkColorInterpolateFromEndpoints: number;
       linkBlending: number;
+      pixelRatio: number;
     };
     drawLineFragmentUniforms: {
       renderMode: number;
@@ -200,6 +201,7 @@ export class Lines extends CoreModule {
           pointDefaultColor: 'vec4<f32>',
           linkColorInterpolateFromEndpoints: 'f32',
           linkBlending: 'f32',
+          pixelRatio: 'f32',
         },
         defaultUniforms: {
           transformationMatrix: store.transformationMatrix4x4,
@@ -230,6 +232,7 @@ export class Lines extends CoreModule {
           pointDefaultColor: ensureVec4(getRgbaColor(config.pointDefaultColor), [0, 0, 0, 1]),
           linkColorInterpolateFromEndpoints: config.linkColorInterpolateFromEndpoints ? 1 : 0,
           linkBlending: config.linkBlending ? 1 : 0,
+          pixelRatio: config.pixelRatio,
         },
       },
       drawLineFragmentUniforms: {
@@ -363,6 +366,7 @@ export class Lines extends CoreModule {
         pointDefaultColor: ensureVec4(this.data.defaultRgba, [0, 0, 0, 1]),
         linkColorInterpolateFromEndpoints: config.linkColorInterpolateFromEndpoints ? 1 : 0,
         linkBlending: config.linkBlending ? 1 : 0,
+        pixelRatio: config.pixelRatio,
       },
       drawLineFragmentUniforms: {
         renderMode: 0.0, // Normal rendering
@@ -908,6 +912,7 @@ export class Lines extends CoreModule {
         // always off): greyed links hidden by unblended rendering must also be
         // absent from the index buffer, and links visible in blended mode pickable.
         linkBlending: config.linkBlending ? 1 : 0,
+        pixelRatio: config.pixelRatio,
       },
       drawLineFragmentUniforms: {
         renderMode: 1.0, // Index rendering for picking
@@ -1148,6 +1153,7 @@ export class Lines extends CoreModule {
       defines: {
         USE_UNIFORM_BUFFERS: true,
         EXIT_DEFAULT_COLOR_CHANNEL: glslFloatLiteral(EXIT_DEFAULT_COLOR_CHANNEL),
+        EDGE_RAMP_PX: glslFloatLiteral(EDGE_RAMP_PX),
       } as unknown as Record<string, boolean>,
       bindings: {
         drawLineUniforms: this.drawLineUniformStore.getManagedUniformBuffer('drawLineUniforms'),

--- a/src/modules/Points/draw-highlighted.frag
+++ b/src/modules/Points/draw-highlighted.frag
@@ -21,24 +21,32 @@ layout(std140) uniform drawHighlightedUniforms {
   vec4 backgroundColor;
   vec4 greyoutColor;
   float width;
+  float pixelRatio;
 } drawHighlighted;
 
 #define width drawHighlighted.width
 #else
 uniform float width;
+uniform float pixelRatio;
 #endif
 
 in vec2 vertexPosition;
 in float pointOpacity;
 in vec3 rgbColor;
+flat in float ringRadiusPx;
+flat in float quadHalfPx;
 
 out vec4 fragColor;
 
-const float smoothing = 1.05;
-
+// Ring band [sqrt(width) × R, R], R the outer radius in device px (`width` is the inner
+// edge as a squared radius). Core at least EDGE_RAMP_PX wide, centred on the band, ramp
+// centred on both edges. A ring is an interface mark: thinner than the ramp it is widened
+// at full alpha, not dimmed.
 void main () {
-  float r = dot(vertexPosition, vertexPosition);
-  float opacity = smoothstep(r, r * smoothing, 1.0);
-  float stroke = smoothstep(width, width * smoothing, r);
-  fragColor = vec4(rgbColor, opacity * stroke * pointOpacity);
+  float rPx = length(vertexPosition) * quadHalfPx;
+  float innerPx = sqrt(width) * ringRadiusPx;
+  float centrePx = (ringRadiusPx + innerPx) * 0.5;
+  float halfCorePx = max(ringRadiusPx - innerPx, EDGE_RAMP_PX) * 0.5;
+  float ring = 1.0 - smoothstep(-EDGE_RAMP_PX * 0.5, EDGE_RAMP_PX * 0.5, abs(rPx - centrePx) - halfCorePx);
+  fragColor = vec4(rgbColor, ring * pointOpacity);
 }

--- a/src/modules/Points/draw-highlighted.vert
+++ b/src/modules/Points/draw-highlighted.vert
@@ -27,9 +27,11 @@ layout(std140) uniform drawHighlightedUniforms {
   vec4 backgroundColor;
   vec4 greyoutColor;
   float width;
+  float pixelRatio;
 } drawHighlighted;
 
 #define size drawHighlighted.size
+#define pixelRatio drawHighlighted.pixelRatio
 #define transformationMatrix drawHighlighted.transformationMatrix
 #define pointsTextureSize drawHighlighted.pointsTextureSize
 #define sizeScale drawHighlighted.sizeScale
@@ -61,24 +63,27 @@ uniform float isDarkenGreyout;
 uniform vec4 backgroundColor;
 uniform vec4 greyoutColor;
 uniform float width;
+uniform float pixelRatio;
 #endif
 out vec2 vertexPosition;
 out float pointOpacity;
 out vec3 rgbColor;
+// Ring outer radius and quad half-size, device px: the ring plus a full ramp per side.
+flat out float ringRadiusPx;
+flat out float quadHalfPx;
 
+// The drawn size (draw-points.vert), device px, so the ring follows it.
 float calculatePointSize(float pointSize) {
   float pSize;
 
-  if (scalePointsOnZoom > 0.0) { 
-    pSize = pointSize * transformationMatrix[0][0];
+  if (scalePointsOnZoom > 0.0) {
+    pSize = pointSize * pixelRatio * transformationMatrix[0][0];
   } else {
-    pSize = pointSize * min(5.0, max(1.0, transformationMatrix[0][0] * 0.01));
+    pSize = pointSize * pixelRatio * min(5.0, max(1.0, transformationMatrix[0][0] * 0.01));
   }
 
-  return min(pSize, maxPointSize);
+  return min(pSize, maxPointSize * pixelRatio);
 }
-
-const float relativeRingRadius = 1.3;
 
 void main () {
   vertexPosition = vertexCoord;
@@ -100,6 +105,12 @@ void main () {
   }
 
   vec4 pointPosition = texelFetch(positionsTexture, pointTexel, 0);
+
+  // A size of 0 has no ring; the quad below is never narrower than the ramp.
+  if (size * sizeScale <= 0.0) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    return;
+  }
 
   rgbColor = color.rgb;
   pointOpacity = color.a * universalPointOpacity;
@@ -136,9 +147,10 @@ void main () {
     }
   }
 
-  // Calculate point radius
-  float pointSize = (calculatePointSize(size * sizeScale) * relativeRingRadius) / transformationMatrix[0][0];
-  float radius = pointSize * 0.5;
+  // Ring radius from the drawn core, device px: a shape under a device pixel is drawn as one.
+  ringRadiusPx = max(calculatePointSize(size * sizeScale), 1.0) * POINT_RING_SCALE * 0.5;
+  quadHalfPx = ringRadiusPx + EDGE_RAMP_PX;
+  float radius = quadHalfPx / pixelRatio / transformationMatrix[0][0];
 
   // Calculate point position in screen space
   vec2 a = pointPosition.xy;

--- a/src/modules/Points/draw-highlighted.vert
+++ b/src/modules/Points/draw-highlighted.vert
@@ -72,17 +72,9 @@ out vec3 rgbColor;
 flat out float ringRadiusPx;
 flat out float quadHalfPx;
 
-// The drawn size (draw-points.vert), device px, so the ring follows it.
+// The drawn size (draw-points.vert), so the ring follows it. `size` is a uniform here.
 float calculatePointSize(float pointSize) {
-  float pSize;
-
-  if (scalePointsOnZoom > 0.0) {
-    pSize = pointSize * pixelRatio * transformationMatrix[0][0];
-  } else {
-    pSize = pointSize * pixelRatio * min(5.0, max(1.0, transformationMatrix[0][0] * 0.01));
-  }
-
-  return min(pSize, maxPointSize * pixelRatio);
+  return pointSizePx(pointSize, pixelRatio, transformationMatrix[0][0], scalePointsOnZoom, maxPointSize);
 }
 
 void main () {

--- a/src/modules/Points/draw-points.frag
+++ b/src/modules/Points/draw-points.frag
@@ -118,15 +118,17 @@ float diamondDistance(vec2 p) {
 
 float pentagonDistance(vec2 p) {
     // Regular pentagon signed-distance (Inigo Quilez)
-    const vec3 k = vec3(0.809016994, 0.587785252, 0.726542528);
+    const vec3 k = vec3(0.809016994, 0.587785252, 0.726542528); // cos 36°, sin 36°, tan 36°
+    const float r = 0.726542528;                                // apothem: the flat edge is at y = r; equal to k.z by
+                                                                // coincidence of the chosen size, not by construction
     p.x = abs(p.x);
 
     // Reflect across the two tilted edges ─ only if point is outside
     p -= 2.0 * min(dot(vec2(-k.x, k.y), p), 0.0) * vec2(-k.x, k.y);
     p -= 2.0 * min(dot(vec2( k.x, k.y), p), 0.0) * vec2( k.x, k.y);
 
-    // Clip against the top horizontal edge (keeps top point sharp)
-    p -= vec2(clamp(p.x, -k.z * k.x, k.z * k.x), k.z);
+    // distance to the flat edge as a segment: every corner folds onto x = ±r·tan 36°
+    p -= vec2(clamp(p.x, -r * k.z, r * k.z), r);
 
     // Return signed distance (negative → inside, positive → outside)
     return length(p) * sign(p.y);

--- a/src/modules/Points/draw-points.frag
+++ b/src/modules/Points/draw-points.frag
@@ -45,9 +45,6 @@ in float overallSize;
 
 out vec4 fragColor;
 
-// Smoothing controls the smoothness of the point's edge
-const float smoothing = 0.9;
-
 // Occlusion culling splits fragments between the opaque core pass (renderMode 1)
 // and the blended fringe pass (renderMode 2) at this final-alpha threshold
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -208,30 +205,43 @@ void main() {
     // Calculate coordinates within the point
     vec2 pointCoord = 2.0 * gl_PointCoord - 1.0;
 
+    // pointCoord covers the full sprite, which is larger than the shape when the point is
+    // outlined, carries a bigger image, or is under a pixel. Rescale it so the shape keeps
+    // its intended size.
+    vec2 shapeCoord = pointCoord;
+    float shapeDiameterPx = overallSize;
+    if (overallSize > shapeSize && shapeSize > 0.0) {
+        shapeCoord = pointCoord * (overallSize / shapeSize);
+        shapeDiameterPx = shapeSize;
+    }
+
     vec4 finalShapeColor = vec4(0.0);
     vec4 finalImageColor = vec4(0.0);
     
-    // Handle shape rendering with centering logic
-    if (pointShape != NONE) {
-        // Calculate shape coordinates with centering
-        vec2 shapeCoord = pointCoord;
-        if (overallSize > shapeSize && shapeSize > 0.0) {
-            // Shape is smaller than overall size, center it
-            float scale = shapeSize / overallSize;
-            shapeCoord = pointCoord / scale;
-        }
-        
+    // Ramp of EDGE_RAMP_PX device pixels centred on the shape edge. The sprite is the shape's own
+    // size: the outer half of the ramp is clipped only where the shape touches the sprite's sides.
+    // A shape under one device pixel is drawn as a one-pixel core with alpha shape² / core², the
+    // ink of its true area; a size of 0 has no shape.
+    if (pointShape != NONE && shapeSize > 0.0) {
+        float coreDiameterPx = max(shapeDiameterPx, 1.0);
+        float smallAlpha = min(1.0, (shapeDiameterPx * shapeDiameterPx) / (coreDiameterPx * coreDiameterPx));
+        vec2 coreCoord = shapeCoord * (shapeDiameterPx / coreDiameterPx); // -1..1 across the core
+        float halfRampPx = EDGE_RAMP_PX * 0.5;
+
         float opacity;
         if (pointShape == CIRCLE) {
-            // For circles, use the original distance calculation
-            float pointCenterDistance = dot(shapeCoord, shapeCoord);
-            opacity = 1.0 - smoothstep(smoothing, 1.0, pointCenterDistance);
+            // Along the radius: a ramp in r² skews coverage outward on small discs.
+            float rPx = length(coreCoord) * coreDiameterPx * 0.5;
+            opacity = 1.0 - smoothstep(coreDiameterPx * 0.5 - halfRampPx, coreDiameterPx * 0.5 + halfRampPx, rPx);
         } else {
-            // For other shapes, use the shape distance function
-            float shapeDistance = getShapeDistance(shapeCoord, pointShape);
-            opacity = 1.0 - smoothstep(-0.01, 0.01, shapeDistance);
+            float shapeDistance = getShapeDistance(coreCoord, pointShape);
+            // Half a ramp in field units, via the field's gradient per pixel: exact for a field that
+            // is linear across the ramp, as every polygon field is at its edge. All fragments of a
+            // sprite share pointShape, so the derivative is taken in coherent control flow.
+            float shapeHalfRamp = max(halfRampPx * length(vec2(dFdx(shapeDistance), dFdy(shapeDistance))), 1e-6);
+            opacity = 1.0 - smoothstep(-shapeHalfRamp, shapeHalfRamp, shapeDistance);
         }
-        opacity *= shapeColor.a;
+        opacity *= smallAlpha * shapeColor.a;
 
         finalShapeColor = vec4(shapeColor.rgb, opacity);
     }
@@ -277,15 +287,22 @@ void main() {
         finalPointAlpha
     );
 
-    // Render outline ring around the point
+    // Outline ring: band [outlineWidth × R, R], R = POINT_RING_SCALE × point radius, device px.
+    // Core at least a ramp wide, centred on the band, ramp centred on both edges. A ring is an
+    // interface mark: thinner than the ramp it is widened at full alpha, not dimmed.
+    //
+    //          inner R      outer R
+    //   ────────░░┤░░████████░░├░░────────
+    //            fade  core   fade
     if (isOutlined > 0.0) {
-        float r = length(pointCoord);
-        const float ringSmoothing = 1.025;
-        float rSafe = max(r, 1e-6);
-        float wSafe = max(outlineWidth, 1e-6);
-        float outerEdge = smoothstep(rSafe, rSafe * ringSmoothing, 1.0);
-        float innerEdge = smoothstep(wSafe, wSafe * ringSmoothing, r);
-        float ringAlpha = outerEdge * innerEdge;
+        // Sized from the drawn core (a shape under a pixel is drawn as one), inside the sprite,
+        // which the hardware cap can clamp: the ring then tightens onto the body.
+        float ringOuterPx = min(POINT_RING_SCALE * max(max(shapeSize, 1.0), imageSizeVarying), overallSize - EDGE_RAMP_PX) * 0.5;
+        float ringInnerPx = outlineWidth * ringOuterPx;
+        float ringCentrePx = (ringOuterPx + ringInnerPx) * 0.5;
+        float ringHalfCorePx = max(ringOuterPx - ringInnerPx, EDGE_RAMP_PX) * 0.5;
+        float rPx = length(pointCoord) * overallSize * 0.5;
+        float ringAlpha = 1.0 - smoothstep(-EDGE_RAMP_PX * 0.5, EDGE_RAMP_PX * 0.5, abs(rPx - ringCentrePx) - ringHalfCorePx);
 
         // Grey out the ring color when the point is greyed
         vec3 ringColor = outlineColor.rgb;

--- a/src/modules/Points/draw-points.frag
+++ b/src/modules/Points/draw-points.frag
@@ -299,11 +299,13 @@ void main() {
         }
 
         float ringOpacity = ringAlpha * outlineColor.a;
-        // Composite ring on top of existing fragment
-        fragColor = vec4(
-            mix(fragColor.rgb, ringColor, ringOpacity),
-            max(fragColor.a, ringOpacity)
-        );
+        // Source-over of the ring onto the fragment. A plain mix would tint the ring with a
+        // transparent body's colour, and the blend would then apply the ring's alpha twice.
+        float outAlpha = ringOpacity + fragColor.a * (1.0 - ringOpacity);
+        vec3 outRgb = outAlpha > 0.0
+            ? (ringColor * ringOpacity + fragColor.rgb * fragColor.a * (1.0 - ringOpacity)) / outAlpha
+            : fragColor.rgb;
+        fragColor = vec4(outRgb, outAlpha);
     }
 
     // Occlusion culling: split every fragment between the opaque core pass

--- a/src/modules/Points/draw-points.frag
+++ b/src/modules/Points/draw-points.frag
@@ -93,14 +93,18 @@ float squareDistance(vec2 p) {
 
 float triangleDistance(vec2 p) {
     const float k = sqrt(3.0);   // ≈1.732; slope of 60° lines for an equilateral triangle
-    p.x = abs(p.x) - 0.9;        // fold the X axis and shift: brings left and right halves together
-    p.y = p.y + 0.55;             // move the whole shape up slightly so it is centred vertically
+    const float r = 0.9;         // half the edge length; each edge is 2r
+    p.x = abs(p.x) - r;          // fold the X axis and shift: the base corner is at the origin
+    p.y += 0.55;                 // move the base (y = -0.55 in the core) to y = 0. The centred offset is
+                                 // r/k = 0.52; 0.55 keeps the apex at 1.01 rather than 1.04
 
-    // reflect points that fall outside the main triangle back inside, to reuse the same maths
+    // Reflect across the corner's bisector: the slanted edge maps onto the x axis,
+    // corner at x = 0, apex at x = -2r
     if (p.x + k * p.y > 0.0)
         p = vec2(p.x - k * p.y,  -k * p.x - p.y) / 2.0;
 
-    p.x -= clamp(p.x, -1.0, 0.0); // clip any remainder on the left side
+    // Distance to the edge as the segment [-2r, 0] on the x axis
+    p.x -= clamp(p.x, -2.0 * r, 0.0);
 
     // Return signed distance: negative = inside; positive = outside
     return -length(p) * sign(p.y);

--- a/src/modules/Points/draw-points.vert
+++ b/src/modules/Points/draw-points.vert
@@ -102,16 +102,9 @@ out float shapeSize;
 out float imageSizeVarying;
 out float overallSize;
 
+// The size rule is the shared pointSize module, so drawing, picking and selection agree on it.
 float calculatePointSize(float size) {
-  float pSize;
-
-  if (scalePointsOnZoom > 0.0) {
-    pSize = size * ratio * transformationMatrix[0][0];
-  } else {
-    pSize = size * ratio * min(5.0, max(1.0, transformationMatrix[0][0] * 0.01));
-  }
-
-  return min(pSize, maxPointSize * ratio);
+  return pointSizePx(size, ratio, transformationMatrix[0][0], scalePointsOnZoom, maxPointSize);
 }
 
 // Read-time resolution of NaN channels — input arrays are used verbatim and never

--- a/src/modules/Points/draw-points.vert
+++ b/src/modules/Points/draw-points.vert
@@ -114,8 +114,6 @@ float calculatePointSize(float size) {
   return min(pSize, maxPointSize * ratio);
 }
 
-const float outlineRingScale = 1.3;
-
 // Read-time resolution of NaN channels — input arrays are used verbatim and never
 // edited, so "use the default" stays encoded as NaN all the way to the GPU. A NaN
 // resolves to the config default blended toward the exit default along the animated
@@ -209,15 +207,25 @@ void main() {
   float shapeSizeValue = calculatePointSize(pointSize * sizeScale);
   float imageSizeValue = calculatePointSize(imageSize * sizeScale);
 
-  // Use the larger of the two sizes for the overall point size
-  float overallSizeValue = max(shapeSizeValue, imageSizeValue);
-
-  // Scale up point sprite to fit outline ring; clamp to hardware gl_PointSize limit so the
-  // sprite never gets silently clipped — the point body is unaffected, only the ring narrows.
-  if (isOutlined > 0.0) {
-    overallSizeValue *= outlineRingScale;
-    overallSizeValue = min(overallSizeValue, maxPointSize * ratio);
+  // A size of 0 draws nothing; the sprite below is never smaller than a pixel.
+  if (max(shapeSizeValue, imageSizeValue) <= 0.0) {
+    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    gl_PointSize = 0.0;
+    return;
   }
+
+  // Use the larger of the shape, image, and 1-pixel minimum. The sprite is the shape's own size:
+  // the ramp stays centred on the edge, and its outer half is clipped where the shape meets the
+  // sprite's sides.
+  float overallSizeValue = max(max(shapeSizeValue, 1.0), imageSizeValue);
+
+  // Outlined: scale the drawn core (a shape is never under a pixel) to the ring size, then add
+  // ramp room on both sides.
+  if (isOutlined > 0.0) {
+    overallSizeValue = POINT_RING_SCALE * max(max(shapeSizeValue, 1.0), imageSizeValue) + 2.0 * EDGE_RAMP_PX;
+  }
+  // Clamp to the hardware limit; the fragment shader preserves the shape size.
+  overallSizeValue = min(overallSizeValue, maxPointSize * ratio);
 
   gl_PointSize = overallSizeValue;
 

--- a/src/modules/Points/fill-picking-buffer.vert
+++ b/src/modules/Points/fill-picking-buffer.vert
@@ -126,6 +126,9 @@ void main() {
 
   float shapeSizeValue = calculatePointSize(resolvedSize * sizeScale, pxPerUnit);
   float imageSizeValue = calculatePointSize(imageSize * sizeScale, pxPerUnit);
+  // A size of 0 draws nothing (draw-points.vert), so it is not hoverable either.
+  if (max(shapeSizeValue, imageSizeValue) <= 0.0) return;
+
   // Device px → CSS px → picking-buffer px (the buffer is smaller than the screen)
   float spriteSize = max(shapeSizeValue, imageSizeValue) / ratio * pickingPixelRatio;
 

--- a/src/modules/Points/fill-picking-buffer.vert
+++ b/src/modules/Points/fill-picking-buffer.vert
@@ -70,19 +70,9 @@ out vec4 rgba;
 // pixels) a point could fall between the buffer's texels.
 const float minPickingSize = 2.0;
 
-// Must stay identical to calculatePointSize in draw-points.vert (same
-// transform-scale semantics), or the picking radius drifts from the rendered
-// point size.
+// The drawn size (draw-points.vert), so the pickable footprint is the rendered point.
 float calculatePointSize(float size, float pxPerUnit) {
-  float pSize;
-
-  if (scalePointsOnZoom > 0.0) {
-    pSize = size * ratio * pxPerUnit;
-  } else {
-    pSize = size * ratio * min(5.0, max(1.0, pxPerUnit * 0.01));
-  }
-
-  return min(pSize, maxPointSize * ratio);
+  return pointSizePx(size, ratio, pxPerUnit, scalePointsOnZoom, maxPointSize);
 }
 
 void main() {

--- a/src/modules/Points/find-points-in-rect.frag
+++ b/src/modules/Points/find-points-in-rect.frag
@@ -43,20 +43,9 @@ uniform float maxPointSize;
 
 out vec4 fragColor;
 
+// The drawn size (draw-points.vert), so the selection footprint is the rendered point.
 float pointSizeF(float size) {
-  float pSize;
-  // Extract top-left element from mat4 (or use mat3 conversion)
-  #ifdef USE_UNIFORM_BUFFERS
-  float scale = transformationMatrix[0][0]; // mat4 first element
-  #else
-  float scale = transformationMatrix[0][0]; // mat3 first element
-  #endif
-  if (scalePointsOnZoom > 0.0) { 
-    pSize = size * ratio * scale;
-  } else {
-    pSize = size * ratio * min(5.0, max(1.0, scale * 0.01));
-  }
-  return min(pSize, maxPointSize * ratio);
+  return pointSizePx(size, ratio, transformationMatrix[0][0], scalePointsOnZoom, maxPointSize);
 }
 
 void main() {

--- a/src/modules/Points/find-points-in-rect.frag
+++ b/src/modules/Points/find-points-in-rect.frag
@@ -43,9 +43,10 @@ uniform float maxPointSize;
 
 out vec4 fragColor;
 
-// The drawn size (draw-points.vert), so the selection footprint is the rendered point.
+// The drawn size (draw-points.vert), so the selection footprint is the rendered point: a shape
+// under a device pixel is drawn as one. In CSS px, the units of the rectangle and screenSize.
 float pointSizeF(float size) {
-  return pointSizePx(size, ratio, transformationMatrix[0][0], scalePointsOnZoom, maxPointSize);
+  return max(pointSizePx(size, ratio, transformationMatrix[0][0], scalePointsOnZoom, maxPointSize), 1.0) / ratio;
 }
 
 void main() {
@@ -70,6 +71,11 @@ void main() {
 
   vec4 pSize = texelFetch(pointSize, pointTexel, 0);
   float size = pSize.r * sizeScale;
+  // A size of 0 draws nothing (draw-points.vert), so it is not selectable either.
+  if (size <= 0.0) {
+    fragColor = vec4(0.0);
+    return;
+  }
 
   float left = 2.0 * (rect0.x - 0.5 * pointSizeF(size)) / screenSize.x - 1.0;
   float right = 2.0 * (rect1.x + 0.5 * pointSizeF(size)) / screenSize.x - 1.0;

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -13,6 +13,7 @@ import drawHighlightedFrag from '@/graph/modules/Points/draw-highlighted.frag?ra
 import drawHighlightedVert from '@/graph/modules/Points/draw-highlighted.vert?raw'
 import fillPickingBufferFrag from '@/graph/modules/Points/fill-picking-buffer.frag?raw'
 import fillPickingBufferVert from '@/graph/modules/Points/fill-picking-buffer.vert?raw'
+import { pointSizeModule } from '@/graph/modules/Points/point-size-module'
 import fillGridWithSampledPointsFrag from '@/graph/modules/Points/fill-sampled-points.frag?raw'
 import fillGridWithSampledPointsVert from '@/graph/modules/Points/fill-sampled-points.vert?raw'
 import updatePositionFrag from '@/graph/modules/Points/update-position.frag?raw'
@@ -739,6 +740,7 @@ export class Points extends CoreModule {
     this.drawCommand ||= new Model(device, {
       fs: drawPointsFrag,
       vs: drawPointsVert,
+      modules: [pointSizeModule],
       topology: 'point-list',
       vertexCount: data.pointsNumber ?? 0,
       attributes: {
@@ -789,6 +791,7 @@ export class Points extends CoreModule {
     this.drawCoreCommand ||= new Model(device, {
       fs: drawPointsFrag,
       vs: drawPointsVert,
+      modules: [pointSizeModule],
       topology: 'point-list',
       vertexCount: data.pointsNumber ?? 0,
       indexBuffer: this.reversedPointIndexBuffer ?? null,
@@ -864,6 +867,7 @@ export class Points extends CoreModule {
     this.findPointsInRectCommand ||= new Model(device, {
       fs: findPointsInRectFrag,
       vs: updateVert,
+      modules: [pointSizeModule],
       topology: 'triangle-strip',
       vertexCount: 4,
       attributes: {
@@ -968,6 +972,7 @@ export class Points extends CoreModule {
     this.fillPickingBufferCommand ||= new Model(device, {
       fs: fillPickingBufferFrag,
       vs: fillPickingBufferVert,
+      modules: [pointSizeModule],
       topology: 'point-list',
       vertexCount: data.pointsNumber ?? 0,
       attributes: {
@@ -1095,6 +1100,7 @@ export class Points extends CoreModule {
     this.drawHighlightedCommand ||= new Model(device, {
       fs: drawHighlightedFrag,
       vs: drawHighlightedVert,
+      modules: [pointSizeModule],
       topology: 'triangle-strip',
       vertexCount: 4,
       attributes: {

--- a/src/modules/Points/index.ts
+++ b/src/modules/Points/index.ts
@@ -4,7 +4,7 @@ import { Model } from '@luma.gl/engine'
 // import { extent } from 'd3-array'
 import { CoreModule } from '@/graph/modules/core-module'
 import type { Mat4Array, Hovered } from '@/graph/modules/Store'
-import { defaultConfigValues, EXIT_DEFAULT_SIZE, EXIT_DEFAULT_COLOR_CHANNEL } from '@/graph/variables'
+import { defaultConfigValues, EXIT_DEFAULT_SIZE, EXIT_DEFAULT_COLOR_CHANNEL, EDGE_RAMP_PX, POINT_RING_SCALE } from '@/graph/variables'
 import drawPointsFrag from '@/graph/modules/Points/draw-points.frag?raw'
 import drawPointsVert from '@/graph/modules/Points/draw-points.vert?raw'
 import findPointsInRectFrag from '@/graph/modules/Points/find-points-in-rect.frag?raw'
@@ -365,6 +365,7 @@ export class Points extends CoreModule {
     drawHighlightedUniforms: {
       color: [number, number, number, number];
       width: number;
+      pixelRatio: number;
       pointIndex: number;
       size: number;
       sizeScale: number;
@@ -767,6 +768,8 @@ export class Points extends CoreModule {
         USE_UNIFORM_BUFFERS: true,
         EXIT_DEFAULT_SIZE: glslFloatLiteral(EXIT_DEFAULT_SIZE),
         EXIT_DEFAULT_COLOR_CHANNEL: glslFloatLiteral(EXIT_DEFAULT_COLOR_CHANNEL),
+        EDGE_RAMP_PX: glslFloatLiteral(EDGE_RAMP_PX),
+        POINT_RING_SCALE: glslFloatLiteral(POINT_RING_SCALE),
       } as unknown as Record<string, boolean>,
       bindings: {
         // Create uniform buffer binding
@@ -813,6 +816,8 @@ export class Points extends CoreModule {
         USE_UNIFORM_BUFFERS: true,
         EXIT_DEFAULT_SIZE: glslFloatLiteral(EXIT_DEFAULT_SIZE),
         EXIT_DEFAULT_COLOR_CHANNEL: glslFloatLiteral(EXIT_DEFAULT_COLOR_CHANNEL),
+        EDGE_RAMP_PX: glslFloatLiteral(EDGE_RAMP_PX),
+        POINT_RING_SCALE: glslFloatLiteral(POINT_RING_SCALE),
       } as unknown as Record<string, boolean>,
       bindings: {
         drawVertexUniforms: this.drawUniformStore.getManagedUniformBuffer('drawVertexUniforms'),
@@ -1062,6 +1067,7 @@ export class Points extends CoreModule {
           greyoutColor: 'vec4<f32>',
           // Fragment shader uniforms (width is in same block):
           width: 'f32',
+          pixelRatio: 'f32',
         },
         defaultUniforms: {
           size: 1,
@@ -1081,6 +1087,7 @@ export class Points extends CoreModule {
           backgroundColor: ensureVec4(store.backgroundColor, [0, 0, 0, 1]),
           greyoutColor: ensureVec4(store.greyoutPointColor, [0, 0, 0, 1]),
           width: 0.85,
+          pixelRatio: config.pixelRatio,
         },
       },
     })
@@ -1098,7 +1105,9 @@ export class Points extends CoreModule {
       ],
       defines: {
         USE_UNIFORM_BUFFERS: true,
-      },
+        EDGE_RAMP_PX: glslFloatLiteral(EDGE_RAMP_PX),
+        POINT_RING_SCALE: glslFloatLiteral(POINT_RING_SCALE),
+      } as unknown as Record<string, boolean>,
       bindings: {
         // Create uniform buffer binding
         // Update it later by calling uniformStore.setUniforms()
@@ -1876,6 +1885,7 @@ export class Points extends CoreModule {
           backgroundColor: ensureVec4(store.backgroundColor, [0, 0, 0, 1]),
           greyoutColor: ensureVec4(store.greyoutPointColor, [0, 0, 0, 1]),
           width: 0.85,
+          pixelRatio: config.pixelRatio,
         },
       })
       // Update texture bindings dynamically
@@ -1911,6 +1921,7 @@ export class Points extends CoreModule {
           backgroundColor: ensureVec4(store.backgroundColor, [0, 0, 0, 1]),
           greyoutColor: ensureVec4(store.greyoutPointColor, [0, 0, 0, 1]),
           width: 0.85,
+          pixelRatio: config.pixelRatio,
         },
       })
       // Update texture bindings dynamically

--- a/src/modules/Points/point-size-module.ts
+++ b/src/modules/Points/point-size-module.ts
@@ -1,0 +1,13 @@
+import type { ShaderModule } from '@luma.gl/shadertools'
+import pointSizeGlsl from '@/graph/modules/Points/point-size.glsl?raw'
+
+/**
+ * Shared GLSL for a point's on-screen size. Used by draw-points.vert, draw-highlighted.vert,
+ * fill-picking-buffer.vert and find-points-in-rect.frag, so the drawn sprite, its ring, its
+ * pickable footprint and its selection footprint agree.
+ */
+export const pointSizeModule: ShaderModule = {
+  name: 'pointSize',
+  vs: pointSizeGlsl,
+  fs: pointSizeGlsl,
+}

--- a/src/modules/Points/point-size.glsl
+++ b/src/modules/Points/point-size.glsl
@@ -1,0 +1,8 @@
+// A point's size in device pixels: the size (CSS px) by the pixel ratio and the zoom — 1:1 with
+// scalePointsOnZoom, otherwise held near constant — capped at the hardware sprite limit.
+// pxPerUnit is the zoom scale. Module code precedes each shader's own uniforms, so they come in
+// as parameters.
+float pointSizePx(float size, float ratio, float pxPerUnit, float scalePointsOnZoom, float maxPointSize) {
+  float zoom = scalePointsOnZoom > 0.0 ? pxPerUnit : min(5.0, max(1.0, pxPerUnit * 0.01));
+  return min(size * ratio * zoom, maxPointSize * ratio);
+}

--- a/src/modules/Zoom/index.ts
+++ b/src/modules/Zoom/index.ts
@@ -179,13 +179,16 @@ export class Zoom {
   }
 
   public convertSpaceToScreenRadius (spaceRadius: number): number {
-    const { config: { scalePointsOnZoom }, store: { maxPointSize }, eventTransform: { k } } = this
+    const { config: { scalePointsOnZoom, pixelRatio }, store: { maxPointSize }, eventTransform: { k } } = this
     let size = spaceRadius * 2
     if (scalePointsOnZoom) {
       size *= k
     } else {
       size *= Math.min(5.0, Math.max(1.0, k * 0.01))
     }
-    return Math.min(size, maxPointSize) / 2
+    // The drawn size (draw-points.vert): a size of 0 draws nothing, a shape is never under a
+    // device pixel, and the hardware sprite limit caps it.
+    if (size <= 0) return 0
+    return Math.min(Math.max(size, 1 / pixelRatio), maxPointSize) / 2
   }
 }

--- a/src/stories/rendering.stories.ts
+++ b/src/stories/rendering.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta } from '@storybook/html'
+
+import { createStory, Story } from '@/graph/stories/create-story'
+import { CosmosStoryProps } from './create-cosmos'
+import { antiAliasing } from './rendering/anti-aliasing'
+
+import antiAliasingStoryRaw from './rendering/anti-aliasing/index?raw'
+
+// How things come out on screen: edges, pixel ratios, blending. These are
+// checks to look at rather than features to copy.
+const meta: Meta<CosmosStoryProps> = {
+  title: 'Examples/Rendering',
+}
+
+export const AntiAliasing: Story = {
+  ...createStory(antiAliasing),
+  name: 'Edge Anti-aliasing at 0.5×, 1×, 2×',
+  tags: ['advanced', 'interactive'],
+  parameters: {
+    sourceCode: [
+      { name: 'Story', code: antiAliasingStoryRaw },
+    ],
+  },
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta

--- a/src/stories/rendering/anti-aliasing/index.ts
+++ b/src/stories/rendering/anti-aliasing/index.ts
@@ -1,0 +1,317 @@
+import { Graph, type GraphConfig, LinkStyle, PointShape } from '@cosmos.gl/graph'
+
+// One page, three pixel ratios. Each pane draws the same scene: every point
+// shape, plain (top) and outlined (bottom), at 0.5–16 px, and a ring of links
+// from 0.25 px to 8 px wide at every angle. The panes share one camera —
+// scroll to zoom and the edges pass through every size on all three at once.
+// The toggles apply to all panes.
+
+const SPACE = 4096
+const PIXEL_RATIOS = [0.5, 1, 2]
+const SHAPES = [
+  PointShape.Circle, PointShape.Square, PointShape.Triangle, PointShape.Diamond,
+  PointShape.Pentagon, PointShape.Hexagon, PointShape.Star, PointShape.Cross,
+]
+const SHAPE_COLORS: [number, number, number][] = [
+  [1.0, 0.42, 0.38], [0.13, 0.55, 0.45], [0.25, 0.32, 0.71], [0.96, 0.76, 0.19],
+  [0.74, 0.24, 0.45], [0.18, 0.55, 0.56], [0.85, 0.45, 0.28], [0.58, 0.44, 0.86],
+]
+const SIZES = [0.5, 1, 2, 4, 8, 16] // CSS px at zoom 1
+const SPOKES = 48
+const WIDTH_RANGE = [0.25, 8] // CSS px at zoom 1, growing clockwise
+const FAN_INNER = 30
+const FAN_OUTER = 120
+
+const hslToRgb = (h: number, s: number, l: number): [number, number, number] => {
+  const f = (n: number): number => {
+    const k = (n + h * 12) % 12
+    const a = s * Math.min(l, 1 - l)
+    return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))
+  }
+  return [f(0), f(8), f(4)]
+}
+
+// ── Scene ───────────────────────────────────────────────────────────────────
+
+type Scene = {
+  positions: Float32Array;
+  colors: Float32Array;
+  sizes: Float32Array;
+  shapes: Float32Array;
+  outlined: number[];
+  // Circle points, for the reference rings: the exact nominal size, drawn in SVG.
+  circles: { index: number; size: number }[];
+  links: Float32Array;
+  linkColors: Float32Array;
+  linkWidths: Float32Array;
+}
+
+const buildScene = (): Scene => {
+  const positions: number[] = []
+  const colors: number[] = []
+  const sizes: number[] = []
+  const shapes: number[] = []
+  const outlined: number[] = []
+  const circles: { index: number; size: number }[] = []
+  const links: number[] = []
+  const linkColors: number[] = []
+  const linkWidths: number[] = []
+
+  const colPitch = 30
+  const rowPitch = 34
+  const gap = 30
+  const gridW = (SHAPES.length - 1) * colPitch
+  const gridH = (SIZES.length - 1) * rowPitch
+  const totalW = gridW + gap + FAN_OUTER * 2
+  const left = SPACE / 2 - totalW / 2
+  const cy = SPACE / 2
+
+  // Two grids of shapes × sizes, one above the other; the lower one is outlined.
+  // Space y grows upward, so rows are laid out from the top edge downward.
+  for (const [block, isOutlined] of [[0, false], [1, true]] as const) {
+    const top = cy + (gridH * 2 + gap) / 2 - block * (gridH + gap)
+    SHAPES.forEach((shape, column) => {
+      SIZES.forEach((size, row) => {
+        const index = positions.length / 2
+        positions.push(left + column * colPitch, top - row * rowPitch)
+        colors.push(...SHAPE_COLORS[column]!, 1)
+        sizes.push(size)
+        shapes.push(shape)
+        if (isOutlined) outlined.push(index)
+        if (shape === PointShape.Circle) circles.push({ index, size })
+      })
+    })
+  }
+
+  // A ring of spokes: link width grows clockwise, hue follows the angle.
+  const fx = left + gridW + gap + FAN_OUTER
+  for (let s = 0; s < SPOKES; s += 1) {
+    const angle = (2 * Math.PI * s) / SPOKES
+    const inner = positions.length / 2
+    positions.push(fx + Math.cos(angle) * FAN_INNER, cy + Math.sin(angle) * FAN_INNER)
+    positions.push(fx + Math.cos(angle) * FAN_OUTER, cy + Math.sin(angle) * FAN_OUTER)
+    colors.push(0.75, 0.75, 0.75, 1, 0.75, 0.75, 0.75, 1)
+    sizes.push(1, 2)
+    shapes.push(PointShape.Circle, PointShape.Circle)
+    links.push(inner, inner + 1)
+    const t = s / (SPOKES - 1)
+    linkWidths.push(WIDTH_RANGE[0]! * (WIDTH_RANGE[1]! / WIDTH_RANGE[0]!) ** t)
+    linkColors.push(...hslToRgb(t, 0.75, 0.62), 1)
+  }
+
+  return {
+    positions: new Float32Array(positions),
+    colors: new Float32Array(colors),
+    sizes: new Float32Array(sizes),
+    shapes: new Float32Array(shapes),
+    outlined,
+    circles,
+    links: new Float32Array(links),
+    linkColors: new Float32Array(linkColors),
+    linkWidths: new Float32Array(linkWidths),
+  }
+}
+
+// ── Panes ───────────────────────────────────────────────────────────────────
+
+type Toggles = {
+  linkBlending: boolean;
+  linkDefaultArrows: boolean;
+  curvedLinks: boolean;
+  scaleOnZoom: boolean;
+  linkDefaultStyle: LinkStyle;
+  referenceRings: boolean;
+}
+
+const paneConfig = (pixelRatio: number, t: Toggles): GraphConfig => ({
+  spaceSize: SPACE,
+  pixelRatio,
+  backgroundColor: '#1a1d23',
+  enableSimulation: false,
+  rescalePositions: false,
+  fitViewOnInit: false,
+  scalePointsOnZoom: t.scaleOnZoom,
+  scaleLinksOnZoom: t.scaleOnZoom,
+  linkBlending: t.linkBlending,
+  linkDefaultArrows: t.linkDefaultArrows,
+  curvedLinks: t.curvedLinks,
+  linkDefaultStyle: t.linkDefaultStyle,
+  renderHoveredPointRing: true,
+  hoveredPointRingColor: '#ffffff',
+  outlinedPointRingColor: '#ffffff',
+  enableDrag: false,
+  linkVisibilityMinTransparency: 0.9,
+})
+
+// The panes share one camera. Cosmos exposes no transform setter, so the
+// zoom is mirrored through the graph's private d3 zoom behavior — story-only.
+type GraphInternals = {
+  canvasD3Selection?: { call: (fn: unknown, transform: unknown) => void };
+  zoomInstance: { behavior: { transform: unknown } };
+}
+
+const applyTransform = (graph: Graph, transform: unknown): void => {
+  const g = graph as unknown as GraphInternals
+  g.canvasD3Selection?.call(g.zoomInstance.behavior.transform, transform)
+}
+
+// Reference rings: an SVG circle of the exact nominal diameter (size × zoom in
+// CSS px, or the constant-size rule when not scaling) over every circle point.
+// A correctly sized point fills the ring; the ring is what a legend would draw.
+const createReferenceOverlay = (host: HTMLElement, graph: Graph, scene: Scene, toggles: Toggles): (() => void) => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;pointer-events:none;overflow:hidden;'
+  const rings = scene.circles.map(() => {
+    const ring = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+    ring.setAttribute('fill', 'none')
+    ring.setAttribute('stroke', 'rgba(255,255,255,0.45)')
+    ring.setAttribute('stroke-width', '1')
+    svg.appendChild(ring)
+    return ring
+  })
+  host.appendChild(svg)
+  return (): void => {
+    svg.style.display = toggles.referenceRings ? '' : 'none'
+    if (!toggles.referenceRings) return
+    const k = graph.getZoomLevel()
+    const scale = toggles.scaleOnZoom ? k : Math.min(5, Math.max(1, k * 0.01))
+    scene.circles.forEach(({ index, size }, i) => {
+      const [x, y] = graph.spaceToScreenPosition([scene.positions[index * 2]!, scene.positions[index * 2 + 1]!])
+      const ring = rings[i]!
+      ring.setAttribute('cx', String(x))
+      ring.setAttribute('cy', String(y))
+      // Stroke centred on the edge: the ring's centreline is the nominal radius.
+      ring.setAttribute('r', String((size * scale) / 2))
+    })
+  }
+}
+
+export const antiAliasing = (): { graph: Graph; div: HTMLDivElement; destroy?: () => void } => {
+  const scene = buildScene()
+  const toggles: Toggles = {
+    linkBlending: true,
+    linkDefaultArrows: false,
+    curvedLinks: false,
+    scaleOnZoom: true,
+    linkDefaultStyle: LinkStyle.Solid,
+    referenceRings: true,
+  }
+
+  const outer = document.createElement('div')
+  outer.style.cssText =
+    'height:100vh;width:100%;background:#1a1d23;color:#e0e0e0;font-family:monospace;font-size:12px;display:flex;flex-direction:column;overflow:hidden;'
+
+  const bar = document.createElement('div')
+  bar.style.cssText = 'padding:8px 14px;display:flex;gap:18px;align-items:center;flex:none;border-bottom:1px solid #3a3f47;'
+  bar.innerHTML = '<span>Shapes 0.5–16 px, plain above and outlined below; links 0.25–8 px clockwise. Scroll to zoom all three.</span>'
+  const zoomLabel = document.createElement('span')
+  zoomLabel.style.cssText = 'margin-left:auto;color:#9aa3ad;'
+  outer.appendChild(bar)
+
+  const panesRow = document.createElement('div')
+  panesRow.style.cssText = 'flex:1;display:flex;min-height:0;'
+  outer.appendChild(panesRow)
+
+  const graphs: Graph[] = []
+  const overlayUpdates: (() => void)[] = []
+  let syncing = false
+
+  PIXEL_RATIOS.forEach((pixelRatio, i) => {
+    const pane = document.createElement('div')
+    pane.style.cssText = `flex:1;min-width:0;display:flex;flex-direction:column;${i > 0 ? 'border-left:1px solid #3a3f47;' : ''}`
+    const header = document.createElement('div')
+    header.style.cssText = 'padding:6px 14px;flex:none;color:#7fd1c0;font-weight:bold;'
+    header.textContent = `pixelRatio ${pixelRatio} — 1 CSS px = ${pixelRatio} device px`
+    const host = document.createElement('div')
+    host.style.cssText = 'flex:1;min-height:0;position:relative;'
+    pane.appendChild(header)
+    pane.appendChild(host)
+    panesRow.appendChild(pane)
+
+    const graph = new Graph(host, {
+      ...paneConfig(pixelRatio, toggles),
+      onZoom: (e, userDriven): void => {
+        updateOverlay()
+        if (!userDriven || syncing) return
+        syncing = true
+        for (const other of graphs) if (other !== graph) applyTransform(other, e.transform)
+        syncing = false
+        zoomLabel.textContent = `zoom ${e.transform.k.toFixed(2)}`
+      },
+    })
+    const updateOverlay = createReferenceOverlay(host, graph, scene, toggles)
+    overlayUpdates.push(updateOverlay)
+    graph.setPointPositions(scene.positions)
+    graph.setPointColors(scene.colors)
+    graph.setPointSizes(scene.sizes)
+    graph.setPointShapes(scene.shapes)
+    graph.setLinks(scene.links)
+    graph.setLinkColors(scene.linkColors)
+    graph.setLinkWidths(scene.linkWidths)
+    graph.setConfigPartial({ outlinedPointIndices: scene.outlined })
+    graph.render()
+    // Fit at zoom 1: a size of n is n CSS px in every pane.
+    graph.setZoomTransformByPointPositions(scene.positions, 0, 1)
+    graphs.push(graph)
+  })
+  const resizeObserver = new ResizeObserver(() => overlayUpdates.forEach((update) => update()))
+  resizeObserver.observe(panesRow)
+
+  const applyToggles = (): void => {
+    for (const graph of graphs) graph.setConfigPartial(paneConfig(graph.config.pixelRatio, toggles))
+    overlayUpdates.forEach((update) => update())
+  }
+
+  const addToggle = (label: string, key: Exclude<keyof Toggles, 'linkDefaultStyle'>): void => {
+    const wrap = document.createElement('label')
+    wrap.style.cssText = 'display:flex;gap:6px;align-items:center;cursor:pointer;'
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    input.checked = toggles[key]
+    input.addEventListener('change', () => {
+      toggles[key] = input.checked
+      applyToggles()
+    })
+    wrap.appendChild(input)
+    wrap.appendChild(document.createTextNode(label))
+    bar.appendChild(wrap)
+  }
+  addToggle('linkBlending', 'linkBlending')
+  addToggle('arrows', 'linkDefaultArrows')
+  addToggle('curved', 'curvedLinks')
+  addToggle('scale on zoom', 'scaleOnZoom')
+  addToggle('reference rings', 'referenceRings')
+  const style = document.createElement('select')
+  style.style.cssText = 'font:inherit;'
+  for (const [label, value] of [['solid', LinkStyle.Solid], ['dashed', LinkStyle.Dashed], ['dotted', LinkStyle.Dotted]] as const) {
+    const option = document.createElement('option')
+    option.textContent = label
+    option.value = String(value)
+    style.appendChild(option)
+  }
+  style.addEventListener('change', () => {
+    toggles.linkDefaultStyle = Number(style.value) as LinkStyle
+    applyToggles()
+  })
+  bar.appendChild(style)
+  const reset = document.createElement('button')
+  reset.textContent = '1:1'
+  reset.style.cssText = 'font:inherit;padding:1px 8px;cursor:pointer;'
+  reset.addEventListener('click', () => {
+    for (const graph of graphs) graph.setZoomTransformByPointPositions(scene.positions, 250, 1)
+    zoomLabel.textContent = 'zoom 1.00'
+  })
+  bar.appendChild(reset)
+  zoomLabel.textContent = 'zoom 1.00'
+  bar.appendChild(zoomLabel)
+
+  return {
+    graph: graphs[0]!,
+    div: outer,
+    destroy: (): void => {
+      resizeObserver.disconnect()
+      // The story contract tears down `graph` (the first pane); the rest are ours.
+      for (const graph of graphs.slice(1)) graph.destroy()
+    },
+  }
+}

--- a/src/stories/rendering/anti-aliasing/index.ts
+++ b/src/stories/rendering/anti-aliasing/index.ts
@@ -282,6 +282,7 @@ export const antiAliasing = (): { graph: Graph; div: HTMLDivElement; destroy?: (
   addToggle('scale on zoom', 'scaleOnZoom')
   addToggle('reference rings', 'referenceRings')
   const style = document.createElement('select')
+  style.setAttribute('aria-label', 'Link style')
   style.style.cssText = 'font:inherit;'
   for (const [label, value] of [['solid', LinkStyle.Solid], ['dashed', LinkStyle.Dashed], ['dotted', LinkStyle.Dotted]] as const) {
     const option = document.createElement('option')

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -160,3 +160,30 @@ export const focusedPointRingOpacity = 0.95
  */
 export const EXIT_DEFAULT_SIZE = 0
 export const EXIT_DEFAULT_COLOR_CHANNEL = 0
+
+/**
+ * Anti-aliasing ramp: the fade from coverage 1 to 0 at every edge the engine draws, in
+ * device pixels, centred on the geometric edge. Reaches the point, link and highlight
+ * shaders as the `EDGE_RAMP_PX` define.
+ *
+ *   coverage
+ *   1 |███████░░
+ *     |         ●        0.5 exactly on the edge
+ *   0 |__________░░___   half the ramp inside, half outside
+ *
+ * A centred fade integrates to the same area as a hard edge, so ink is independent of shape
+ * size and pixel ratio. Thinner than the ramp, each element keeps what matters for it:
+ *
+ *   link   → drawn at ramp width, alpha = width / ramp   (ink preserved)
+ *   ring   → drawn at ramp width, alpha = 1              (visibility preserved)
+ *   point  → 1 px core, alpha = shape² / core²           (ink preserved)
+ *
+ * 1.0 is the box filter: a straight edge deposits in each pixel exactly the area it covers.
+ */
+export const EDGE_RAMP_PX = 1.0
+
+/**
+ * A ring's outer radius over its point's radius, for the outline ring and the hover / focus
+ * ring alike. Reaches the point and highlight shaders as the `POINT_RING_SCALE` define.
+ */
+export const POINT_RING_SCALE = 1.3


### PR DESCRIPTION
Every edge fade was a fraction of its shape, not a number of pixels — a 4 px point on a 1× display got a 0.1 px fade, rings vanished under ~20 px, and a 1 px link's ink depended on where it fell between pixels. This was hidden while `pixelRatio` was hardcoded to 2; since v3 it follows the device.

Now every edge fades over exactly one device pixel, centred on the geometric edge (`EDGE_RAMP_PX` in `variables.ts`). A centred fade keeps the shape's ink and its size at every pixel ratio — a point measures what a legend draws in SVG.

- Points: sprite stays the shape's own size (a padded sprite was measured: 12–45 % of the frame on 1M points — set aside, numbers in `history/`). Circles fade along r; polygons from their field's gradient.
- Links: quad is `max(width, ramp) + ramp`; arrow body/head, dash caps and dots share the ramp. New `pixelRatio` uniform.
- Rings: a band on the ring's centre line, ramp on each edge, sized from the drawn core.
- Two shape fields were not the distances they claimed (triangle apex segment, pentagon half side); fixed on the way.
- Outline ring composited source-over instead of `mix`/`max`, which tinted it with a transparent body.
- One size rule: `point-size.glsl` (a luma shader module) shared by draw, ring, picking and rect selection; `spaceToScreenRadius` mirrors it. Rect selection padded a CSS-px rectangle by a device-px size (2× too wide on retina, pre-existing) — fixed.

Thinner than the ramp, each element keeps what matters for it:

| element | rule |
|---|---|
| link | drawn at ramp width, `alpha = width / ramp` — ink preserved |
| ring | drawn at ramp width, alpha 1 — visibility preserved |
| point < 1 px | 1 px core, `alpha = shape² / core²` — ink preserved |
| size 0 / width 0 | nothing: not drawn, hovered, selected; radius 0 |
| unblended | hard cut at the edge, floored at 1 device px; dots at ≥ √2 px |

Frame time vs `main`, 1M points, M3: +0–14 % at 4 device px, +1–2 % at 8 and below 2; links +0–9 %. Full tables in `history/2026/2026-09-10-edge-ramps.md`.

New story *Examples → Rendering → Edge Anti-aliasing at 0.5×, 1×, 2×*: one scene in three panes at three pixel ratios, shared camera, SVG reference rings at each circle's nominal size, toggles for blending / arrows / curves / link style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive rendering example showcasing edge anti-aliasing at 0.5×, 1×, and 2× pixel ratios.
  - Added a Rendering section to the Storybook sidebar.

- **Improvements**
  - Improved anti-aliasing for points, links, outlines, rings, arrows, dashes, and dots across different pixel densities.
  - Standardized on-screen sizing across rendering, highlighting, picking, and rectangular selection.
  - Zero-sized points and links are no longer rendered or selectable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->